### PR TITLE
reformating cause travis to fail build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: java
 
-brefore_script:
-   - export MAVEN_OPTS="-XX:MaxPermSize=256m -Xmx1024m"
+global:
+   env:
+     - MAVEN_OPTS="-XX:MaxPermSize=256m -Xmx1024m"
 
-script: mvn -Parchetype -Pscaladoc clean install 
+install: mvn -Parchetype -Preformat -DskipTests clean install
+
+script:
+   - mvn -Parchetype  test
+   - .travis/reformat.sh
 
 jdk:
    - openjdk6
-   - oraclejdk7
-   - oraclejdk8
 
 notifications:
   email:

--- a/.travis/reformat.sh
+++ b/.travis/reformat.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+branch=$( git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/' | tr -d '()' )
+
+if [[ $branch != "master" ]]
+then
+
+    if ! git diff-files --quiet --ignore-submodules --ignore-space-at-eol --
+    then
+        echo >&2 "cannot build: you have unstaged changes."
+        exit -1
+    fi
+
+    # Disallow uncommitted changes in the index
+    if ! git diff-index --cached --quiet HEAD --ignore-submodules --ignore-space-at-eol --
+    then
+        echo >&2 "cannot build: your index contains uncommitted changes."
+        exit -1
+    fi
+
+fi


### PR DESCRIPTION
This should prevent travis from building sources which are not correctly formatted. This should not modify the result of the build but just a a new phase which would fail if the sources need reformat.
