### PR TITLE
more elegant multicast

### DIFF
--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/CamelDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/CamelDSL.scala
@@ -39,6 +39,7 @@ trait CamelDSL extends StepProcessor[RouteBuilder] with Basics
     with Aggregation
     with Transaction
     with Transformation
+    with MulticastFunctional
     with Marshaller
     with RouteId
     with Enricher

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/MulticastFunctionalDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/MulticastFunctionalDSL.scala
@@ -24,7 +24,7 @@ class MulticastFunctionalDSL[I: ClassTag](multi: MulticastFunctionalDefinition[I
   /**
    * @return the possibility to add other steps to the current DSL
    */
-  def castTo(id: String): BaseDSL[I] = {
+  def route(id: String): BaseDSL[I] = {
 
     val whenDef = new MultiDefinition[I](id)
 

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/MulticastFunctionalDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/MulticastFunctionalDSL.scala
@@ -1,0 +1,53 @@
+/*
+ *
+ *  Copyright 2010-2014 Crossing-Tech SA, EPFL QI-J, CH-1015 Lausanne, Switzerland.
+ *  All rights reserved.
+ *
+ * ==================================================================================
+ */
+package io.xtech.babel.camel
+
+import io.xtech.babel.fish.BaseDSL
+import io.xtech.babel.fish.model._
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+
+/**
+ * sub DSL for the MultiDSL. Let define branches to cast to.
+ * @param multi represents the multicast to which we are adding branches.
+ * @tparam I the input type of this keyword.
+ */
+class MulticastFunctionalDSL[I: ClassTag](multi: MulticastFunctionalDefinition[I]) extends BaseDSL[I](multi) {
+
+  /**
+   * @return the possibility to add other steps to the current DSL
+   */
+  def castTo(id: String): BaseDSL[I] = {
+
+    val whenDef = new MultiDefinition[I](id)
+
+    multi.scopedSteps = multi.scopedSteps :+ whenDef
+
+    new BaseDSL[I](whenDef)
+  }
+}
+
+/**
+ * DSL adding the multi keyword, a functional version of the multicast.
+ */
+
+class MultiDSL[I: ClassTag](step: StepDefinition) extends BaseDSL[I](step) {
+
+  def multi(cast: (MulticastFunctionalDSL[I] => Unit)): BaseDSL[I] = {
+    val multicast = new MulticastFunctionalDefinition[I]
+    step.next = Some(multicast)
+
+    val multiDSL = new MulticastFunctionalDSL[I](multicast)
+    cast(multiDSL)
+
+    new BaseDSL(multicast)
+  }
+}
+

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/CamelSink.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/CamelSink.scala
@@ -8,7 +8,9 @@
 
 package io.xtech.babel.camel.model
 
-import io.xtech.babel.fish.model.Sink
+import io.xtech.babel.camel.SubRouteDSL
+import io.xtech.babel.fish.BaseDSL
+import io.xtech.babel.fish.model.{ScopeDefinition, StepDefinition, Sink}
 
 import scala.collection.immutable
 

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/MulticastFunctional.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/MulticastFunctional.scala
@@ -1,0 +1,48 @@
+/*
+ *
+ *  Copyright 2010-2014 Crossing-Tech SA, EPFL QI-J, CH-1015 Lausanne, Switzerland.
+ *  All rights reserved.
+ *
+ * ==================================================================================
+ */
+
+package io.xtech.babel.camel.parsing
+
+import io.xtech.babel.camel.{CamelDSL, MultiDSL}
+import io.xtech.babel.fish.BaseDSL
+import io.xtech.babel.fish.model.MulticastFunctionalDefinition
+import io.xtech.babel.fish.parsing.StepInformation
+import org.apache.camel.model.ProcessorDefinition
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+/**
+ * The `multi` parser
+ */
+private[babel] trait MulticastFunctional extends CamelParsing {
+  self: CamelDSL =>
+
+  abstract override def steps = super.steps :+ parse
+
+  implicit def multicastDSLExtension[I: ClassTag](baseDsl: BaseDSL[I]) = new MultiDSL[I](baseDsl.step)
+
+  /**
+   * Parsing of the functional mutlicast
+   */
+  private def parse: Process = {
+    case s@StepInformation(multicast: MulticastFunctionalDefinition[_], camelProcessorDefinition: ProcessorDefinition[_]) => {
+
+      val uris = multicast.scopedSteps.map(x => s"direct:${x.branchId}")
+      val javaUris = uris.toArray
+
+      multicast.scopedSteps.foreach(multi => {
+        val rest = s.buildHelper.from(s"direct:${multi.branchId}").routeId(multi.branchId)
+        multi.next.foreach(n => process(n, rest)(s.buildHelper))
+      })
+
+      camelProcessorDefinition.multicast().to(javaUris: _*)
+
+    }
+  }
+}

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
@@ -85,9 +85,9 @@ class MulticastSpec extends SpecificationWithJUnit {
       from("direct:input").as[String].
         //received messages are sent to those three mock endpoints
         multi(cast => {
-         cast.castTo("output1").processBody(_ + "1").to("mock:output1")
-         cast.castTo("output2").processBody(_ + "2").to("mock:output2")
-         cast.castTo("output3").processBody(_ + "3").to("mock:output3")
+         cast.route("output1").processBody(_ + "1").to("mock:output1")
+         cast.route("output2").processBody(_ + "2").to("mock:output2")
+         cast.route("output3").processBody(_ + "3").to("mock:output3")
       }).
         to("mock:output4")
     }

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
@@ -74,4 +74,47 @@ class MulticastSpec extends SpecificationWithJUnit {
     mockEndpoint3.assertIsSatisfied()
     mockEndpoint4.assertIsSatisfied()
   }
+
+  "create a multicast in a functional way" in new camel {
+
+    import io.xtech.babel.camel.builder.RouteBuilder
+
+    //#doc:babel-camel-multicast-functional
+
+    val routeDef = new RouteBuilder {
+      from("direct:input").as[String].
+        //received messages are sent to those three mock endpoints
+        multi(cast => {
+         cast.castTo("output1").processBody(_ + "1").to("mock:output1")
+         cast.castTo("output2").processBody(_ + "2").to("mock:output2")
+         cast.castTo("output3").processBody(_ + "3").to("mock:output3")
+      }).
+        to("mock:output4")
+    }
+    //#doc:babel-camel-multicast-functional
+
+    routeDef.addRoutesToCamelContext(camelContext)
+
+    camelContext.start()
+
+    val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
+    val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
+    val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
+    val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
+
+    mockEndpoint1.expectedBodiesReceived("test1")
+    mockEndpoint2.expectedBodiesReceived("test2")
+    mockEndpoint3.expectedBodiesReceived("test3")
+    mockEndpoint4.expectedBodiesReceived("test")
+
+    val producer = camelContext.createProducerTemplate()
+
+    producer.sendBody("direct:input", "test")
+
+    mockEndpoint1.assertIsSatisfied()
+    mockEndpoint2.assertIsSatisfied()
+    mockEndpoint3.assertIsSatisfied()
+    mockEndpoint4.assertIsSatisfied()
+  }
+
 }

--- a/babel-fish/src/main/scala/io/xtech/babel/fish/model/BaseDefinition.scala
+++ b/babel-fish/src/main/scala/io/xtech/babel/fish/model/BaseDefinition.scala
@@ -38,6 +38,19 @@ case class EndpointDefinition[I, O](sink: Sink[I, O], requestReply: Option[Boole
 case class MulticastDefinition[I](sinks: immutable.Seq[Sink[I, _]]) extends StepDefinition
 
 /**
+ * The definition of a multicast. A multicast routes the same message to multiple endpoints (sink).
+ * @tparam I the body type of the input message.
+ */
+case class MulticastFunctionalDefinition[I]() extends ScopeDefinition[MultiDefinition[I]]
+
+/**
+ * The definition of a multicast branch.
+ * @param branchId to identify the branch where the messages are sent
+ * @tparam I the body type of the input message.
+ */
+case class MultiDefinition[I](branchId: String) extends StepDefinition
+
+/**
   * The definition of a body message conversion.
   * @param outClass the new type of the body message.
   */


### PR DESCRIPTION
This version is inspired by the choice keyword. It uses the same behavior as the sub keyword (using the direct component) to create new routes.