### PR TITLE
throttler (fixed unit: second)

### DIFF
--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/CamelDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/CamelDSL.scala
@@ -39,6 +39,7 @@ trait CamelDSL extends StepProcessor[RouteBuilder] with Basics
     with Aggregation
     with Transaction
     with Transformation
+    with Throttler
     with Marshaller
     with RouteId
     with Enricher

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/EnricherDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/EnricherDSL.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model.{ PollEnrichRefDefinition, EnrichRefDefinition, EnrichDefinition, PollEnrichDefinition }

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/MarshallerDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/MarshallerDSL.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model._

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/ThrottlerDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/ThrottlerDSL.scala
@@ -1,0 +1,42 @@
+/*
+ *
+ *  Copyright 2010-2014 Crossing-Tech SA, EPFL QI-J, CH-1015 Lausanne, Switzerland.
+ *  All rights reserved.
+ *
+ * ==================================================================================
+ */
+
+package io.xtech.babel.camel
+
+import io.xtech.babel.camel.model.{ThrottlerDefinitionExpression, ThrottlerDefinitionLong}
+import io.xtech.babel.fish.model.{Expression, Message}
+import io.xtech.babel.fish.{BaseDSL, DSL2BaseDSL, MessageExpression}
+
+import scala.reflect.ClassTag
+
+/**
+ * DSL adding the throttle keyword
+ */
+class ThrottlerDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) extends DSL2BaseDSL[I] {
+
+  /**
+   * The throttle keyword. Defines the maximal rate that may be use in order to avoid overloading of the rest of the route
+   * @param perSecond number of allowed messages in 1 second
+   * @return the possibility to add other steps to the current DSL
+   */
+  def throttle(perSecond: Long): BaseDSL[I] = ThrottlerDefinitionLong(perSecond)
+
+  /**
+   * The throttle keyword. Defines the maximal rate that may be use in order to avoid overloading of the rest of the route
+   * @param perSecond number of allowed messages in 1 second using an expression
+   * @return the possibility to add other steps to the current DSL
+   */
+  def throttle(perSecond: Expression[I, Long]): BaseDSL[I] = ThrottlerDefinitionExpression(perSecond)
+
+  /**
+   * The throttle keyword. Defines the maximal rate that may be use in order to avoid overloading of the rest of the route
+   * @param perSecond number of allowed messages in 1 second using a function
+   * @return the possibility to add other steps to the current DSL
+   */
+  def throttle(perSecond: Message[I] => Long): BaseDSL[I] = ThrottlerDefinitionExpression(MessageExpression(perSecond))
+}

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/ValidationDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/ValidationDSL.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model.ValidationDefinition

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/ThrottlerDefinition.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/ThrottlerDefinition.scala
@@ -1,0 +1,23 @@
+/*
+ *
+ *  Copyright 2010-2014 Crossing-Tech SA, EPFL QI-J, CH-1015 Lausanne, Switzerland.
+ *  All rights reserved.
+ *
+ * ==================================================================================
+ */
+
+package io.xtech.babel.camel.model
+
+import io.xtech.babel.fish.model.{Expression, StepDefinition}
+
+/**
+ * Declaration of a throttler definition
+ * @param perSecond maximal number of message allowed per second
+ */
+case class ThrottlerDefinitionLong(perSecond: Long) extends StepDefinition
+
+/**
+ * Declaration of a throttler definition
+ * @param perSecond expression defining maximal number of message allowed per second
+ */
+case class ThrottlerDefinitionExpression[I](perSecond: Expression[I, Long]) extends StepDefinition

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/ValidationDefinition.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/ValidationDefinition.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel.model
 
 import io.xtech.babel.fish.model.{ Predicate, StepDefinition }

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/Throttler.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/Throttler.scala
@@ -1,0 +1,36 @@
+/*
+ *
+ *  Copyright 2010-2014 Crossing-Tech SA, EPFL QI-J, CH-1015 Lausanne, Switzerland.
+ *  All rights reserved.
+ *
+ * ==================================================================================
+ */
+
+package io.xtech.babel.camel.parsing
+
+import io.xtech.babel.camel.ThrottlerDSL
+import io.xtech.babel.camel.model.{ThrottlerDefinitionLong, ThrottlerDefinitionExpression, Expressions}
+import io.xtech.babel.fish.BaseDSL
+import io.xtech.babel.fish.parsing.StepInformation
+import org.apache.camel.model.ProcessorDefinition
+
+import scala.reflect.ClassTag
+
+/**
+ * Defines the parsing of the throttle keyword.
+ */
+trait Throttler extends CamelParsing {
+
+  abstract override def steps = super.steps :+ parse
+
+  private val parse: Process = {
+    case StepInformation(ThrottlerDefinitionLong(perSecond), camelProcessor: ProcessorDefinition[_]) =>
+      camelProcessor.throttle(perSecond)
+
+    case StepInformation(ThrottlerDefinitionExpression(perSecond), camelProcessor: ProcessorDefinition[_]) =>
+      camelProcessor.throttle(Expressions.toCamelExpression(perSecond))
+
+  }
+
+  implicit def throttlerDSLExtension[I: ClassTag](baseDsl: BaseDSL[I]) = new ThrottlerDSL(baseDsl)
+}

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/Validation.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/Validation.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel.parsing
 
 import io.xtech.babel.camel.ValidationDSL

--- a/babel-camel/babel-camel-core/src/test/resources/log4j.properties
+++ b/babel-camel/babel-camel-core/src/test/resources/log4j.properties
@@ -9,7 +9,7 @@
 #
 # The logging properties used for eclipse testing, We want to see debug output on the console.
 #
-log4j.rootLogger=ERROR, out
+log4j.rootLogger=INFO, out
 
 # uncomment the following line to turn on Camel debugging
 #log4j.logger.org.apache.camel=DEBUG

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/CompilationSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/CompilationSpec.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel
 
 import io.xtech.babel.fish.model.Message

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model.ReduceBodyAggregationStrategy

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MarshallerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MarshallerSpec.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel
 
 import java.util.{ ArrayList ⇒ JArrayList, HashMap => JHashMap }

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SortSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SortSpec.scala
@@ -5,6 +5,7 @@
  *
  * ==================================================================================
  */
+
 package io.xtech.babel.camel
 
 import java.util.{ List => JList }

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/ThrottlerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/ThrottlerSpec.scala
@@ -1,0 +1,71 @@
+/*
+ *
+ *  Copyright 2010-2014 Crossing-Tech SA, EPFL QI-J, CH-1015 Lausanne, Switzerland.
+ *  All rights reserved.
+ *
+ * ==================================================================================
+ */
+
+package io.xtech.babel.camel
+
+import io.xtech.babel.camel.builder.RouteBuilder
+import io.xtech.babel.camel.test.camel
+import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
+import org.apache.camel.component.mock.MockEndpoint
+import org.specs2.mutable.SpecificationWithJUnit
+
+class ThrottlerSpec extends SpecificationWithJUnit {
+  sequential
+
+  "throttle message flow" in new camel {
+
+    val msgs = 3
+
+    //#doc:babel-camel-throttler
+
+    val routeDef = new RouteBuilder {
+      from("direct:input").
+        //throttle message to 1 per second
+        throttle(1).
+        to("mock:output")
+    }
+    //#doc:babel-camel-throttler
+
+    val nativeRoute = new CRouteBuilder() {
+      def configure() {
+        from("direct:inputCamel").
+          throttle(1).
+          to("mock:output")
+      }
+    }
+
+    routeDef.addRoutesToCamelContext(camelContext)
+    camelContext.addRoutes(nativeRoute)
+
+    camelContext.start()
+
+    val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+
+    mockEndpoint.setExpectedMessageCount(msgs)
+
+    val producer = camelContext.createProducerTemplate()
+
+    val initTime = System.currentTimeMillis()
+    (1 to msgs).foreach(_ => producer.sendBody("direct:inputCamel", "test"))
+
+    mockEndpoint.assertIsSatisfied()
+    (System.currentTimeMillis() - initTime) must be_>=(1000l)
+
+    mockEndpoint.reset()
+
+    mockEndpoint.setExpectedMessageCount(msgs)
+
+    val camelInitTime = System.currentTimeMillis()
+    println(camelInitTime)
+    (1 to msgs).foreach(_ => producer.sendBody("direct:input", "test"))
+
+    mockEndpoint.assertIsSatisfied()
+    println(System.currentTimeMillis())
+    (System.currentTimeMillis() - camelInitTime) must be_>=(1000l)
+  }
+}


### PR DESCRIPTION
This adds a throttle keyword to the babel-camel-core dsl. It does not currently let you define the time unit and throttle x msg/s (as the camel default behavior).