### PR TITLE
add a warning for the enrich keyword

### DIFF
--- a/babel-doc/source/camel/transformation.rst
+++ b/babel-doc/source/camel/transformation.rst
@@ -68,6 +68,9 @@ The pollEnrich is more polling the endpoint with a timeout if no message is rece
 
 .. includecode:: ../../../babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala#doc:babel-camel-enricher-2
 
+.. warning:: It's not recommended to us the enrich and pollEnrich keywords with the io.xtech.babel.camel.model.FoldBodyAggregationStrategy. The only supported Aggregation strategy are io.xtech.babel.camel.model.ReduceBodyAggregationStrategy and custom implementations of the org.apache.camel.processor.aggregate.AggregationStrategy Interface.
+
+
 Processors
 ++++++++++
 


### PR DESCRIPTION
I add a comment for the enrich keyword in the documentation.

The enrich keyword is not working with every Babel Aggregation Strategy.