### PR TITLE
improve the enrich keyword api

### DIFF
--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/EnricherDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/EnricherDSL.scala
@@ -7,9 +7,10 @@
  */
 package io.xtech.babel.camel
 
-import io.xtech.babel.camel.model.{ EnrichDefinition, PollEnrichDefinition }
+import io.xtech.babel.camel.model.{PollEnrichRefDefinition, EnrichRefDefinition, EnrichDefinition, PollEnrichDefinition}
 import io.xtech.babel.fish.{ BaseDSL, DSL2BaseDSL }
 import io.xtech.babel.fish.model.Sink
+import org.apache.camel.processor.aggregate.AggregationStrategy
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -32,9 +33,24 @@ private[camel] class EnricherDSL[I: ClassTag](protected val baseDsl: BaseDSL[I])
     * @tparam S the native type of the Sink.
     * @return the possibility to add other steps to the current DSL.
     */
-  def enrich[O: ClassTag, S](sink: S, aggregationStrategyRef: String)(implicit convert: S => Sink[I, O]): BaseDSL[O] = {
+  def enrichRef[O: ClassTag, S](sink: S, aggregationStrategyRef: String)(implicit convert: S => Sink[I, O]): BaseDSL[O] = {
 
-    EnrichDefinition[I, O](sink, aggregationStrategyRef)
+    EnrichRefDefinition[I, O](sink, aggregationStrategyRef)
+  }
+
+  /**
+   * Enrich a message with the data coming from an endpoint using request-reply pattern.
+   * @param sink the endpoint.
+   * @param aggregationStrategy an instance of an AggregationStrategy that know
+   *                               how the original message and the message coming from the endpoint are aggregated.
+   * @param convert converts the endpoint to a Sink.
+   * @tparam O the output type of the enrichment.
+   * @tparam S the native type of the Sink.
+   * @return the possibility to add other steps to the current DSL.
+   */
+  def enrich[O: ClassTag, S](sink: S, aggregationStrategy: AggregationStrategy)(implicit convert: S => Sink[I, O]): BaseDSL[O] = {
+
+    EnrichDefinition[I, O](sink, aggregationStrategy)
   }
 
   /**
@@ -49,11 +65,29 @@ private[camel] class EnricherDSL[I: ClassTag](protected val baseDsl: BaseDSL[I])
     * @tparam S the native type of the Sink.
     * @return the possibility to add other steps to the current DSL.
     */
-  def pollEnrich[O: ClassTag, S](sink: S, aggregationStrategyRef: String, timeout: Int = -1)(implicit convert: S => Sink[I, O]): BaseDSL[O] = {
+  def pollEnrichRef[O: ClassTag, S](sink: S, aggregationStrategyRef: String, timeout: Int = -1)(implicit convert: S => Sink[I, O]): BaseDSL[O] = {
 
-    PollEnrichDefinition[I, O](sink, aggregationStrategyRef, timeout)
+    PollEnrichRefDefinition[I, O](sink, aggregationStrategyRef, timeout)
 
   }
 
+
+  /**
+   * Enrich a message with data coming from an enpoint. The pollEnrich keyword is polling the endpoint.
+   * @param sink the endpoint.
+   * @param aggregationStrategy an instance of an AggregationStrategy that know
+   *                               how the original message and the message coming from the endpoint are aggregated.
+   * @param timeout the timeout when polling the endpoint in milliseconds.
+   *                Possible values : -1 (block until there is a message, 0 don't wait and return immediately, otherwise wait a specific period of time.
+   * @param convert converts the endpoint to a Sink.
+   * @tparam O the output type of the enrichment.
+   * @tparam S the native type of the Sink.
+   * @return the possibility to add other steps to the current DSL.
+   */
+  def pollEnrich[O: ClassTag, S](sink: S, aggregationStrategy: AggregationStrategy, timeout: Int = -1)(implicit convert: S => Sink[I, O]): BaseDSL[O] = {
+
+    PollEnrichDefinition[I, O](sink, aggregationStrategy, timeout)
+
+  }
 }
 

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/EnrichDefinition.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/EnrichDefinition.scala
@@ -9,13 +9,24 @@
 package io.xtech.babel.camel.model
 
 import io.xtech.babel.fish.model.{ Sink, StepDefinition }
+import org.apache.camel.processor.aggregate.AggregationStrategy
 
 /**
-  * The definition a enrich keyword in the DSL
+  * The definition of the enrichRef keyword in the DSL
   */
-case class EnrichDefinition[I, O](val sink: Sink[I, O], val aggregationStrategyRef: String) extends StepDefinition
+case class EnrichRefDefinition[I, O](sink: Sink[I, O], aggregationStrategyRef: String) extends StepDefinition
 
 /**
-  * The definition a pollEnrich keyword in the DSL
+ * The definition of the enrich keyword in the DSL
+ */
+case class EnrichDefinition[I, O](sink: Sink[I, O], aggregationStrategy: AggregationStrategy) extends StepDefinition
+
+/**
+  * The definition of the pollEnrichRef keyword in the DSL
   */
-case class PollEnrichDefinition[I, O](val sink: Sink[I, O], val aggregationStrategyRef: String, val timeout: Long = -1) extends StepDefinition
+case class PollEnrichRefDefinition[I, O](sink: Sink[I, O], aggregationStrategyRef: String, timeout: Long = -1) extends StepDefinition
+
+/**
+ * The definition of the pollEnrich keyword in the DSL
+ */
+case class PollEnrichDefinition[I, O](sink: Sink[I, O], aggregationStrategy: AggregationStrategy, timeout: Long = -1) extends StepDefinition

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/Enricher.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/Enricher.scala
@@ -9,7 +9,7 @@
 package io.xtech.babel.camel.parsing
 
 import io.xtech.babel.camel.EnricherDSL
-import io.xtech.babel.camel.model.{ PollEnrichDefinition, CamelSink, EnrichDefinition }
+import io.xtech.babel.camel.model._
 import io.xtech.babel.fish.BaseDSL
 import io.xtech.babel.fish.parsing.StepInformation
 
@@ -31,8 +31,8 @@ private[babel] trait Enricher extends CamelParsing {
     */
   private def parse: Process = {
 
-    // parsing of the enrich keyword
-    case StepInformation(EnrichDefinition(CamelSink(resourceUri), aggregationRef), camelProcessorDefinition: ProcessorDefinition[_]) => {
+    // parsing of the enrichRef keyword
+    case StepInformation(EnrichRefDefinition(CamelSink(resourceUri), aggregationRef), camelProcessorDefinition: ProcessorDefinition[_]) => {
 
       val camelEnrichDefinition = new CamelEnrichDefinition
       camelEnrichDefinition.setResourceUri(resourceUri)
@@ -43,8 +43,20 @@ private[babel] trait Enricher extends CamelParsing {
       camelProcessorDefinition
     }
 
-    // parsing of the pollenrich keyword
-    case StepInformation(PollEnrichDefinition(CamelSink(resourceUri), aggregationRef, timeout), camelProcessorDefinition: ProcessorDefinition[_]) => {
+    // parsing of the enrich keyword
+    case StepInformation(EnrichDefinition(CamelSink(resourceUri), aggregationStrategy), camelProcessorDefinition: ProcessorDefinition[_]) => {
+
+      val camelEnrichDefinition = new CamelEnrichDefinition
+      camelEnrichDefinition.setResourceUri(resourceUri)
+      camelEnrichDefinition.setAggregationStrategy(aggregationStrategy)
+
+      camelProcessorDefinition.addOutput(camelEnrichDefinition)
+
+      camelProcessorDefinition
+    }
+
+    // parsing of the pollEnrich keyword
+    case StepInformation(PollEnrichRefDefinition(CamelSink(resourceUri), aggregationRef, timeout), camelProcessorDefinition: ProcessorDefinition[_]) => {
 
       val camelPollEnrichDefinition = new CamelPollEnrichDefinition
       camelPollEnrichDefinition.setResourceUri(resourceUri)
@@ -56,6 +68,18 @@ private[babel] trait Enricher extends CamelParsing {
       camelProcessorDefinition
     }
 
+    // parsing of the pollEnrichRef keyword
+    case StepInformation(PollEnrichDefinition(CamelSink(resourceUri), aggregationStrategy, timeout), camelProcessorDefinition: ProcessorDefinition[_]) => {
+
+      val camelPollEnrichDefinition = new CamelPollEnrichDefinition
+      camelPollEnrichDefinition.setResourceUri(resourceUri)
+      camelPollEnrichDefinition.setAggregationStrategy(aggregationStrategy)
+      camelPollEnrichDefinition.setTimeout(timeout)
+
+      camelProcessorDefinition.addOutput(camelPollEnrichDefinition)
+
+      camelProcessorDefinition
+    }
   }
 
 }

--- a/babel-doc/source/camel/transformation.rst
+++ b/babel-doc/source/camel/transformation.rst
@@ -59,14 +59,20 @@ Stream resequencing re-orders (continuous) message streams based on the detectio
 Enrich
 ++++++
 
-The *enrich* and pollEnrich retrieves additional data from an endpoint and let you combine the original and new message with
-an aggregator. The *enrich* is using a request-reply pattern with the endpoint.
+The *enrich* and *pollEnrich* keywords retrieve additional data from an endpoint and let you combine the original and the new message with
+an aggregator.
+
+The *enrich* is using a request-reply pattern with a endpoint (ex: Web Service) to obtain more data.
 
 .. includecode:: ../../../babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala#doc:babel-camel-enricher-1
 
-The pollEnrich is more polling the endpoint with a timeout if no message is received after a while.
-
 .. includecode:: ../../../babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala#doc:babel-camel-enricher-2
+
+The *pollEnrich* is using a Polling Consumer from an endpoint (ex: JMS, SEDA, File) to obtain more data.
+
+.. includecode:: ../../../babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala#doc:babel-camel-enricher-3
+
+.. includecode:: ../../../babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala#doc:babel-camel-enricher-4
 
 .. warning:: It's not recommended to us the enrich and pollEnrich keywords with the io.xtech.babel.camel.model.FoldBodyAggregationStrategy. The only supported Aggregation strategy are io.xtech.babel.camel.model.ReduceBodyAggregationStrategy and custom implementations of the org.apache.camel.processor.aggregate.AggregationStrategy Interface.
 


### PR DESCRIPTION
The old api was only accepting reference to Aggregation Strategy.
I renamed the old keywords : enrich to enrichRef and pollEnrich to pollEnrichRef.
And I created new version of the enrich and pollEnrich keywords that accepts instance of an Aggregation Strategy.
