### PR TITLE
specific dsl for subdsl possibilities

### DIFF
--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/RecipientListDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/RecipientListDSL.scala
@@ -9,6 +9,7 @@
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model.RecipientListDefinition
+import io.xtech.babel.camel.parsing.RecipientlistDSL
 import io.xtech.babel.fish.model.{ Expression, Message }
 import io.xtech.babel.fish.{ BaseDSL, DSL2BaseDSL, MessageExpression }
 import scala.reflect.ClassTag
@@ -21,9 +22,11 @@ private[camel] class RecipientListDSL[I: ClassTag](protected val baseDsl: BaseDS
     * @tparam E
     * @return the possibility to add other steps to the current DSL
     */
-  def recipientList[E](function: Message[I] => E): BaseDSL[I] = {
+  def recipientList[E](function: Message[I] => E): RecipientlistDSL[I] = {
 
-    RecipientListDefinition(MessageExpression(function))
+    val definition = RecipientListDefinition(MessageExpression(function))
+    baseDsl.step.next = Some(definition)
+    new RecipientlistDSL[I](definition)
   }
 
   /**
@@ -32,9 +35,11 @@ private[camel] class RecipientListDSL[I: ClassTag](protected val baseDsl: BaseDS
     * @tparam E type the targets (endpoints)
     * @return the possibility to add other steps to the current DSL
     */
-  def recipientList[E](expression: Expression[I, E]): BaseDSL[I] = {
+  def recipientList[E](expression: Expression[I, E]): RecipientlistDSL[I] = {
 
-    RecipientListDefinition(expression)
+    val definition = RecipientListDefinition(expression)
+    baseDsl.step.next = Some(definition)
+    new RecipientlistDSL[I](definition)
   }
 
 }

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/RecipientList.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/RecipientList.scala
@@ -11,6 +11,7 @@ package io.xtech.babel.camel.parsing
 import io.xtech.babel.camel.RecipientListDSL
 import io.xtech.babel.camel.model.{ Expressions, RecipientListDefinition }
 import io.xtech.babel.fish.BaseDSL
+import io.xtech.babel.fish.model.StepDefinition
 import io.xtech.babel.fish.parsing.StepInformation
 import org.apache.camel.model.ProcessorDefinition
 import scala.collection.immutable
@@ -36,3 +37,5 @@ private[babel] trait RecipientList extends CamelParsing {
     }
   }
 }
+
+protected[babel] class RecipientlistDSL[I: ClassTag](step: StepDefinition) extends BaseDSL[I](step)


### PR DESCRIPTION
This allows us to add sub dsl specific for each eip which is defined such as what has been done for multicast, split and recipientList.