### PR TITLE
allow access to the camel exchange

### DIFF
--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/CamelDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/CamelDSL.scala
@@ -80,11 +80,15 @@ trait CamelDSL extends StepProcessor[RouteBuilder] with Basics
     routeBuilder
   }
 
-  implicit protected def camelMessage[I](msg: Message[I]): CamelMessage[I] = msg match {
+  implicit def camelMessage[I](msg: Message[I]): CamelMessage[I] = CamelHelper.camelMessage(msg)
+
+}
+
+object CamelHelper {
+  implicit def camelMessage[I](msg: Message[I]): CamelMessage[I] = msg match {
     case m: CamelMessage[I] => m
     case other              => throw new IllegalArgumentException(s"Messages in Babel Camel should always be CamelMessage, but was $other")
   }
-
 }
 
 object CamelException {

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/builder/RouteBuilder.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/builder/RouteBuilder.scala
@@ -9,8 +9,8 @@
 package io.xtech.babel.camel.builder
 
 import io.xtech.babel.camel._
-import io.xtech.babel.camel.model.EmptyDefinition
-import io.xtech.babel.fish.model.RouteDefinition
+import io.xtech.babel.camel.model.{ CamelMessage, EmptyDefinition }
+import io.xtech.babel.fish.model.{ Message, RouteDefinition }
 import io.xtech.babel.fish.{ DSL, NoDSL }
 import org.apache.camel.model.ModelCamelContext
 import org.apache.camel.{ CamelContext, RoutesBuilder, RuntimeCamelException }

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/CamelMessage.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/CamelMessage.scala
@@ -9,7 +9,7 @@
 package io.xtech.babel.camel.model
 
 import io.xtech.babel.fish.model.Message
-import org.apache.camel.{ ExchangePattern, Message => NativeMessage }
+import org.apache.camel.{ Message => NativeMessage, Exchange, ExchangePattern }
 import scala.collection.JavaConverters._
 import scala.reflect._
 
@@ -130,6 +130,8 @@ class CamelMessage[I](message: NativeMessage) extends Message[I] {
     new CamelMessage[I](message)
   }
 
-  //the link to the wrapped exchange is cut as main functionnalities are provided directly in the current class.
-  //def nativeMessage = message
+  /**
+    * @return the Camel Exchange which is represented by this CamelMessage.
+    */
+  def exchange: Exchange = message.getExchange
 }


### PR DESCRIPTION
Some developers have complained that the Camel Exchange may be required in some specific cases. For example, some Camel Component generates specific Exchanges (that inherit from the Camel Exchange interface). Thus, to be able to _cast_ those, those developers would require to have access to the Camel Exchange.