### PR TITLE
Cpa mock type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,5 @@ notifications:
      on_success: never  #default: change
      on_failure: always #default: always
   irc: "irc.codehaus.org#babel" 
+
+sudo: false  

--- a/babel-camel/babel-camel-core/pom.xml
+++ b/babel-camel/babel-camel-core/pom.xml
@@ -31,6 +31,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.xtech.babel</groupId>
+            <artifactId>babel-camel-mock_2.11</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/RecipientList.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/RecipientList.scala
@@ -39,4 +39,4 @@ private[babel] trait RecipientList extends CamelParsing { self: CamelDSL =>
   }
 }
 
-protected[babel] class RecipientlistDSL[I: ClassTag](step: StepDefinition) extends BaseDSL[I](step)
+class RecipientlistDSL[I: ClassTag](step: StepDefinition) extends BaseDSL[I](step)

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AggregateSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AggregateSpec.scala
@@ -57,9 +57,9 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+    val mockEndpoint = camelContext.mockEndpoint({output})
     mockEndpoint.expectedMessageCount(1)
-    val mockCamel = camelContext.getEndpoint("mock:camel").asInstanceOf[MockEndpoint]
+    val mockCamel = camelContext.mockEndpoint({camel})
     mockCamel.expectedMessageCount(1)
 
     producer.sendBody(directConsumer, "1")
@@ -124,9 +124,9 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+    val mockEndpoint = camelContext.mockEndpoint({output})
     mockEndpoint.expectedMessageCount(1)
-    val mockCamel = camelContext.getEndpoint("mock:camel").asInstanceOf[MockEndpoint]
+    val mockCamel = camelContext.mockEndpoint({camel})
     mockCamel.expectedMessageCount(1)
 
     producer.sendBody(directConsumer, "1")
@@ -192,8 +192,8 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-    val camelEndpoint = camelContext.getEndpoint("mock:camel").asInstanceOf[MockEndpoint]
+    val mockEndpoint = camelContext.mockEndpoint({output})
+    val camelEndpoint = camelContext.mockEndpoint({camel})
 
     mockEndpoint.expectedBodiesReceived(6: Integer, 15: Integer, 24: Integer)
     camelEndpoint.expectedBodiesReceived(6: Integer, 15: Integer, 24: Integer)
@@ -260,8 +260,8 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-    val mockCamel = camelContext.getEndpoint("mock:camel").asInstanceOf[MockEndpoint]
+    val mockEndpoint = camelContext.mockEndpoint({output})
+    val mockCamel = camelContext.mockEndpoint({camel})
 
     mockEndpoint.expectedBodiesReceived("123", "456", "789")
     mockCamel.expectedBodiesReceived("123", "456", "789")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AggregateSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AggregateSpec.scala
@@ -13,6 +13,7 @@ import io.xtech.babel.camel.model.Aggregation.{ CamelAggregation, CompletionSize
 import io.xtech.babel.camel.test.camel
 import io.xtech.babel.fish.MessageExpression
 import io.xtech.babel.fish.model.Message
+import io.xtech.babel.camel.mock._
 import org.apache.camel.Exchange
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
 import org.apache.camel.component.mock.MockEndpoint
@@ -57,9 +58,9 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.mockEndpoint({output})
+    val mockEndpoint = camelContext.mockEndpoint("output")
     mockEndpoint.expectedMessageCount(1)
-    val mockCamel = camelContext.mockEndpoint({camel})
+    val mockCamel = camelContext.mockEndpoint("camel")
     mockCamel.expectedMessageCount(1)
 
     producer.sendBody(directConsumer, "1")
@@ -124,9 +125,9 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.mockEndpoint({output})
+    val mockEndpoint = camelContext.mockEndpoint("output")
     mockEndpoint.expectedMessageCount(1)
-    val mockCamel = camelContext.mockEndpoint({camel})
+    val mockCamel = camelContext.mockEndpoint("camel")
     mockCamel.expectedMessageCount(1)
 
     producer.sendBody(directConsumer, "1")
@@ -192,8 +193,8 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.mockEndpoint({output})
-    val camelEndpoint = camelContext.mockEndpoint({camel})
+    val mockEndpoint = camelContext.mockEndpoint("output")
+    val camelEndpoint = camelContext.mockEndpoint("camel")
 
     mockEndpoint.expectedBodiesReceived(6: Integer, 15: Integer, 24: Integer)
     camelEndpoint.expectedBodiesReceived(6: Integer, 15: Integer, 24: Integer)
@@ -260,8 +261,8 @@ class AggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint = camelContext.mockEndpoint({output})
-    val mockCamel = camelContext.mockEndpoint({camel})
+    val mockEndpoint = camelContext.mockEndpoint("output")
+    val mockCamel = camelContext.mockEndpoint("camel")
 
     mockEndpoint.expectedBodiesReceived("123", "456", "789")
     mockCamel.expectedBodiesReceived("123", "456", "789")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AsSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AsSpec.scala
@@ -40,7 +40,7 @@ class AsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedBodiesReceived("1234")
 
@@ -67,7 +67,7 @@ class AsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedBodiesReceived("1234")
 
@@ -90,7 +90,7 @@ class AsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedBodiesReceived(List(1, 2, 3))
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AsSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/AsSpec.scala
@@ -10,7 +10,7 @@ package io.xtech.babel.camel
 
 import io.xtech.babel.camel.test.camel
 import org.apache.camel.Exchange
-import org.apache.camel.component.mock.MockEndpoint
+import io.xtech.babel.camel.mock._
 import org.apache.camel.support.TypeConverterSupport
 import org.specs2.mutable.SpecificationWithJUnit
 
@@ -40,7 +40,7 @@ class AsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("1234")
 
@@ -67,7 +67,7 @@ class AsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("1234")
 
@@ -90,7 +90,7 @@ class AsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived(List(1, 2, 3))
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/CamelDSLSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/CamelDSLSpec.scala
@@ -55,7 +55,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint("mock:output")
       mockEndpoint.expectedBodiesReceived(message)
 
       producer.sendBody("direct:input", message)
@@ -80,7 +80,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint("mock:output")
       mockEndpoint.expectedBodiesReceived(message)
       mockEndpoint.expectedExchangePattern(ExchangePattern.InOnly)
 
@@ -106,7 +106,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint("mock:output")
       mockEndpoint.expectedBodiesReceived(message)
       mockEndpoint.expectedExchangePattern(ExchangePattern.InOut)
 
@@ -135,7 +135,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEnpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEnpoint = camelContext.mockEndpoint({output})
       mockEnpoint.expectedBodiesReceived("blablibli")
 
       producer.sendBody("direct:input", "blabli")
@@ -164,7 +164,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEnpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEnpoint = camelContext.mockEndpoint({output})
       mockEnpoint.expectedBodiesReceived("blablibli")
 
       producer.sendBody("direct:input", "blabli")
@@ -192,7 +192,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       producer.sendBody("direct:input", message)
 
@@ -219,7 +219,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       val exchange = new DefaultExchange(camelContext)
       exchange.setProperty("babel", "bli")
@@ -248,7 +248,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       producer.sendBody("direct:input", message) must throwA[Exception]
 
@@ -274,7 +274,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       producer.sendBody("direct:input", message)
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/CamelDSLSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/CamelDSLSpec.scala
@@ -13,6 +13,7 @@ import javax.management.ObjectName
 import io.xtech.babel.camel.builder.RouteBuilder
 import io.xtech.babel.camel.test.camel
 import io.xtech.babel.fish.RouteDefinitionException
+import io.xtech.babel.camel.mock._
 import org.apache.camel._
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.impl.DefaultExchange
@@ -55,7 +56,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
       mockEndpoint.expectedBodiesReceived(message)
 
       producer.sendBody("direct:input", message)
@@ -80,7 +81,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
       mockEndpoint.expectedBodiesReceived(message)
       mockEndpoint.expectedExchangePattern(ExchangePattern.InOnly)
 
@@ -106,7 +107,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
       mockEndpoint.expectedBodiesReceived(message)
       mockEndpoint.expectedExchangePattern(ExchangePattern.InOut)
 
@@ -135,7 +136,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEnpoint = camelContext.mockEndpoint({output})
+      val mockEnpoint = camelContext.mockEndpoint("output")
       mockEnpoint.expectedBodiesReceived("blablibli")
 
       producer.sendBody("direct:input", "blabli")
@@ -164,7 +165,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEnpoint = camelContext.mockEndpoint({output})
+      val mockEnpoint = camelContext.mockEndpoint("output")
       mockEnpoint.expectedBodiesReceived("blablibli")
 
       producer.sendBody("direct:input", "blabli")
@@ -192,7 +193,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       producer.sendBody("direct:input", message)
 
@@ -219,7 +220,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       val exchange = new DefaultExchange(camelContext)
       exchange.setProperty("babel", "bli")
@@ -248,7 +249,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       producer.sendBody("direct:input", message) must throwA[Exception]
 
@@ -274,7 +275,7 @@ class CamelDSLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       producer.sendBody("direct:input", message)
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala
@@ -10,7 +10,7 @@ package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model.{ FoldBodyAggregationStrategy, ReduceBodyAggregationStrategy }
 import io.xtech.babel.camel.test.camel
-import io.xtech.babel.camel.mock.Mock._
+import io.xtech.babel.camel.mock._
 import org.apache.camel.CamelExecutionException
 import org.apache.camel.builder.SimpleBuilder
 import org.apache.camel.component.mock.MockEndpoint
@@ -48,8 +48,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
-      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val enricherMockEndpoint = camelContext.mockEndpoint("enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -82,8 +82,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
-      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val enricherMockEndpoint = camelContext.mockEndpoint("enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -100,15 +100,15 @@ class EnricherSpec extends SpecificationWithJUnit {
 
       //#doc:babel-camel-enricher-funct
 
-      val routeDef = new RouteBuilder {
-        from("direct:enricherRoute").to("mock:enricher")
+      val routeDef = new RouteBuilder with Mock {
+        from("direct:enricherRoute").mock("enricher")
 
         from("direct:input").
           requireAs[String].
           //enriches the input with the enricherRoute messages
           //  using the aggregationStrategy
           enrich("direct:enricherRoute", (a: String, b: Any) => s"${a}${b.toString.toInt}").
-          to("mock:output")
+          mock("output")
       }
 
       //#doc:babel-camel-enricher-func
@@ -116,8 +116,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint("mock:enricher")
-      val enricherMockEndpoint = camelContext.mockEndoint("mock:enricher")
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val enricherMockEndpoint = camelContext.mockEndpoint("enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123", "bli123")
@@ -150,7 +150,7 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val enricherMockEndpoint = camelContext.mockEndoint("mock:enricher")
+      val enricherMockEndpoint = camelContext.mockEndpoint("enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       val producer = camelContext.createProducerTemplate()
@@ -181,8 +181,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
-      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val enricherMockEndpoint = camelContext.mockEndpoint("enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -214,8 +214,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
-      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val enricherMockEndpoint = camelContext.mockEndpoint("enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -244,8 +244,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
-      val enricherMockEndpoint = camelContext.mockEndoint("mock:enricher")
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val enricherMockEndpoint = camelContext.mockEndpoint("enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/EnricherSpec.scala
@@ -10,6 +10,7 @@ package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model.{ FoldBodyAggregationStrategy, ReduceBodyAggregationStrategy }
 import io.xtech.babel.camel.test.camel
+import io.xtech.babel.camel.mock.Mock._
 import org.apache.camel.CamelExecutionException
 import org.apache.camel.builder.SimpleBuilder
 import org.apache.camel.component.mock.MockEndpoint
@@ -47,8 +48,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val enricherMockEndpoint = camelContext.getEndpoint("mock:enricher").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
+      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -81,8 +82,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val enricherMockEndpoint = camelContext.getEndpoint("mock:enricher").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
+      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -115,8 +116,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val enricherMockEndpoint = camelContext.getEndpoint("mock:enricher").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint("mock:enricher")
+      val enricherMockEndpoint = camelContext.mockEndoint("mock:enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123", "bli123")
@@ -149,7 +150,7 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val enricherMockEndpoint = camelContext.getEndpoint("mock:enricher").asInstanceOf[MockEndpoint]
+      val enricherMockEndpoint = camelContext.mockEndoint("mock:enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       val producer = camelContext.createProducerTemplate()
@@ -180,8 +181,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val enricherMockEndpoint = camelContext.getEndpoint("mock:enricher").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
+      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -213,8 +214,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val enricherMockEndpoint = camelContext.getEndpoint("mock:enricher").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
+      val enricherMockEndpoint = camelContext.mockEndpoint({enricher})
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")
@@ -243,8 +244,8 @@ class EnricherSpec extends SpecificationWithJUnit {
       routeDef.addRoutesToCamelContext(camelContext)
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val enricherMockEndpoint = camelContext.getEndpoint("mock:enricher").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val enricherMockEndpoint = camelContext.mockEndoint("mock:enricher")
       enricherMockEndpoint.returnReplyBody(new SimpleBuilder("123"))
 
       mockEndpoint.expectedBodiesReceived("bla123")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/HandlerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/HandlerSpec.scala
@@ -10,6 +10,7 @@ package io.xtech.babel.camel
 
 import io.xtech.babel.camel.builder.RouteBuilder
 import io.xtech.babel.camel.test.camel
+import io.xtech.babel.camel.mock._
 import io.xtech.babel.fish.model.Message
 import io.xtech.babel.fish.{ BodyPredicate, MessagePredicate }
 import org.apache.camel.component.mock.MockEndpoint
@@ -591,7 +592,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
+      val mockCamelSuccess = camelContext.mockEndpoint("camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -617,7 +618,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.mockEndpoint({success})
+      val mockSuccess = camelContext.mockEndpoint("success")
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -649,9 +650,9 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelError = camelContext.mockEndoint("mock:camel-error")
+      val mockCamelError = camelContext.mockEndpoint("camel-error")
       mockCamelError.setExpectedMessageCount(0)
-      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
+      val mockCamelSuccess = camelContext.mockEndpoint("camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -678,9 +679,9 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockError = camelContext.mockEndpoint({error})
+      val mockError = camelContext.mockEndpoint("error")
       mockError.setExpectedMessageCount(0)
-      val mockSuccess = camelContext.mockEndpoint({success})
+      val mockSuccess = camelContext.mockEndpoint("success")
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -768,7 +769,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
+      val mockCamelSuccess = camelContext.mockEndpoint("camel-success")
       mockCamelSuccess.setExpectedMessageCount(0)
 
       val routes = new RouteBuilder {
@@ -790,7 +791,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.mockEndpoint({success})
+      val mockSuccess = camelContext.mockEndpoint("success")
       mockSuccess.setExpectedMessageCount(0)
 
       val proc = camelContext.createProducerTemplate()
@@ -1374,7 +1375,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
+      val mockCamelSuccess = camelContext.mockEndpoint("camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -1400,7 +1401,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.mockEndpoint({success})
+      val mockSuccess = camelContext.mockEndpoint("success")
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -1432,9 +1433,9 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelError = camelContext.mockEndoint("mock:camel-error")
+      val mockCamelError = camelContext.mockEndpoint("camel-error")
       mockCamelError.setExpectedMessageCount(0)
-      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
+      val mockCamelSuccess = camelContext.mockEndpoint("camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -1464,9 +1465,9 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockError = camelContext.mockEndpoint({error})
+      val mockError = camelContext.mockEndpoint("error")
       mockError.setExpectedMessageCount(0)
-      val mockSuccess = camelContext.mockEndpoint({success})
+      val mockSuccess = camelContext.mockEndpoint("success")
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -1559,7 +1560,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
+      val mockCamelSuccess = camelContext.mockEndpoint("camel-success")
       mockCamelSuccess.setExpectedMessageCount(0)
 
       val routes = new RouteBuilder {
@@ -1573,7 +1574,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.mockEndpoint({success})
+      val mockSuccess = camelContext.mockEndpoint("success")
       mockSuccess.setExpectedMessageCount(0)
 
       val proc = camelContext.createProducerTemplate()
@@ -1617,9 +1618,9 @@ class HandlerSpec extends SpecificationWithJUnit {
         from("direct:handlingRoute").log("error:${body}").to("mock:error")
       }
 
-      val mock = camelContext.mockEndoint("mock:error")
-      val mock1 = camelContext.mockEndoint("mock:babel1")
-      val mock2 = camelContext.mockEndoint("mock:babel2")
+      val mock = camelContext.mockEndpoint("error")
+      val mock1 = camelContext.mockEndpoint("babel1")
+      val mock2 = camelContext.mockEndpoint("babel2")
 
       mock.setExpectedMessageCount(2)
       mock1.setExpectedMessageCount(0)

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/HandlerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/HandlerSpec.scala
@@ -591,7 +591,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.getEndpoint("mock:camel-success").asInstanceOf[MockEndpoint]
+      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -617,7 +617,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.getEndpoint("mock:success").asInstanceOf[MockEndpoint]
+      val mockSuccess = camelContext.mockEndpoint({success})
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -649,9 +649,9 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelError = camelContext.getEndpoint("mock:camel-error").asInstanceOf[MockEndpoint]
+      val mockCamelError = camelContext.mockEndoint("mock:camel-error")
       mockCamelError.setExpectedMessageCount(0)
-      val mockCamelSuccess = camelContext.getEndpoint("mock:camel-success").asInstanceOf[MockEndpoint]
+      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -678,9 +678,9 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockError = camelContext.getEndpoint("mock:error").asInstanceOf[MockEndpoint]
+      val mockError = camelContext.mockEndpoint({error})
       mockError.setExpectedMessageCount(0)
-      val mockSuccess = camelContext.getEndpoint("mock:success").asInstanceOf[MockEndpoint]
+      val mockSuccess = camelContext.mockEndpoint({success})
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -768,7 +768,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.getEndpoint("mock:camel-success").asInstanceOf[MockEndpoint]
+      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
       mockCamelSuccess.setExpectedMessageCount(0)
 
       val routes = new RouteBuilder {
@@ -790,7 +790,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.getEndpoint("mock:success").asInstanceOf[MockEndpoint]
+      val mockSuccess = camelContext.mockEndpoint({success})
       mockSuccess.setExpectedMessageCount(0)
 
       val proc = camelContext.createProducerTemplate()
@@ -1374,7 +1374,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.getEndpoint("mock:camel-success").asInstanceOf[MockEndpoint]
+      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -1400,7 +1400,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.getEndpoint("mock:success").asInstanceOf[MockEndpoint]
+      val mockSuccess = camelContext.mockEndpoint({success})
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -1432,9 +1432,9 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelError = camelContext.getEndpoint("mock:camel-error").asInstanceOf[MockEndpoint]
+      val mockCamelError = camelContext.mockEndoint("mock:camel-error")
       mockCamelError.setExpectedMessageCount(0)
-      val mockCamelSuccess = camelContext.getEndpoint("mock:camel-success").asInstanceOf[MockEndpoint]
+      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
       mockCamelSuccess.setExpectedMessageCount(1)
 
       val routes = new RouteBuilder {
@@ -1464,9 +1464,9 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockError = camelContext.getEndpoint("mock:error").asInstanceOf[MockEndpoint]
+      val mockError = camelContext.mockEndpoint({error})
       mockError.setExpectedMessageCount(0)
-      val mockSuccess = camelContext.getEndpoint("mock:success").asInstanceOf[MockEndpoint]
+      val mockSuccess = camelContext.mockEndpoint({success})
       mockSuccess.setExpectedMessageCount(1)
 
       val proc = camelContext.createProducerTemplate()
@@ -1559,7 +1559,7 @@ class HandlerSpec extends SpecificationWithJUnit {
 
       camelContext.addRoutes(new CamelRoute())
 
-      val mockCamelSuccess = camelContext.getEndpoint("mock:camel-success").asInstanceOf[MockEndpoint]
+      val mockCamelSuccess = camelContext.mockEndoint("mock:camel-success")
       mockCamelSuccess.setExpectedMessageCount(0)
 
       val routes = new RouteBuilder {
@@ -1573,7 +1573,7 @@ class HandlerSpec extends SpecificationWithJUnit {
       camelContext.addRoutes(routes)
       camelContext.start()
 
-      val mockSuccess = camelContext.getEndpoint("mock:success").asInstanceOf[MockEndpoint]
+      val mockSuccess = camelContext.mockEndpoint({success})
       mockSuccess.setExpectedMessageCount(0)
 
       val proc = camelContext.createProducerTemplate()
@@ -1617,9 +1617,9 @@ class HandlerSpec extends SpecificationWithJUnit {
         from("direct:handlingRoute").log("error:${body}").to("mock:error")
       }
 
-      val mock = camelContext.getEndpoint("mock:error").asInstanceOf[MockEndpoint]
-      val mock1 = camelContext.getEndpoint("mock:babel1").asInstanceOf[MockEndpoint]
-      val mock2 = camelContext.getEndpoint("mock:babel2").asInstanceOf[MockEndpoint]
+      val mock = camelContext.mockEndoint("mock:error")
+      val mock1 = camelContext.mockEndoint("mock:babel1")
+      val mock2 = camelContext.mockEndoint("mock:babel2")
 
       mock.setExpectedMessageCount(2)
       mock1.setExpectedMessageCount(0)

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/IdSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/IdSpec.scala
@@ -170,7 +170,7 @@ class IdSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEnpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEnpoint = camelContext.mockEndoint("mock:output")
       mockEnpoint.expectedBodiesReceived("blablibli")
 
       producer.sendBody("direct:input", "blabli")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/IdSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/IdSpec.scala
@@ -12,7 +12,7 @@ import io.xtech.babel.camel.builder.RouteBuilder
 import io.xtech.babel.camel.test.camel
 import io.xtech.babel.fish.NamingStrategy
 import io.xtech.babel.fish.model.StepDefinition
-import org.apache.camel.component.mock.MockEndpoint
+import io.xtech.babel.camel.mock._
 import org.apache.camel.model.ModelCamelContext
 import org.apache.camel.{ Exchange, Processor }
 import org.specs2.mutable._
@@ -170,7 +170,7 @@ class IdSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEnpoint = camelContext.mockEndoint("mock:output")
+      val mockEnpoint = camelContext.mockEndpoint("output")
       mockEnpoint.expectedBodiesReceived("blablibli")
 
       producer.sendBody("direct:input", "blabli")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MarshallerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MarshallerSpec.scala
@@ -90,7 +90,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedBodyReceived().body().isEqualTo(outputData)
 
@@ -122,7 +122,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedMessageCount(1)
 
@@ -151,7 +151,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedMessageCount(1)
 
@@ -175,7 +175,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedBodyReceived().body().isEqualTo(outputData)
 
@@ -203,7 +203,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       mockEndpoint.expectedBodiesReceived("""{"a":"1","b":{"@c":"2"},"d":{"e":"3","f":"4"}}""")
 
@@ -238,7 +238,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
 
       val expectedXml = """<?xml version="1.0" encoding="UTF-8"?><o><root><a>1</a><b c="2"/><d><e>3</e><f>4</f></d></root></o>"""
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MarshallerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MarshallerSpec.scala
@@ -13,6 +13,7 @@ import java.util.{ ArrayList => JArrayList, HashMap => JHashMap }
 import io.xtech.babel.camel.MarshallerSpec.{ camelCsv, camelJsonXml }
 import io.xtech.babel.camel.model.CamelMessagePredicate
 import io.xtech.babel.camel.test.camel
+import io.xtech.babel.camel.mock._
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.dataformat.csv.CsvDataFormat
 import org.apache.camel.dataformat.xmljson.XmlJsonDataFormat
@@ -90,7 +91,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodyReceived().body().isEqualTo(outputData)
 
@@ -122,7 +123,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedMessageCount(1)
 
@@ -151,7 +152,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedMessageCount(1)
 
@@ -175,7 +176,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodyReceived().body().isEqualTo(outputData)
 
@@ -203,7 +204,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("""{"a":"1","b":{"@c":"2"},"d":{"e":"3","f":"4"}}""")
 
@@ -238,7 +239,7 @@ class MarshallerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       val expectedXml = """<?xml version="1.0" encoding="UTF-8"?><o><root><a>1</a><b c="2"/><d><e>3</e><f>4</f></d></root></o>"""
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MockSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MockSpec.scala
@@ -9,6 +9,7 @@
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.builder.RouteBuilder
+import io.xtech.babel.camel.mock._
 import org.apache.camel.impl.DefaultCamelContext
 import org.specs2.mutable.SpecificationWithJUnit
 
@@ -16,7 +17,6 @@ class MockSpec extends SpecificationWithJUnit {
   sequential
 
   "extend the DSL with some sub DSL (mock)" in {
-
 
     val camelContext = new DefaultCamelContext()
 
@@ -56,7 +56,7 @@ class MockSpec extends SpecificationWithJUnit {
     mockEndpoint1.assertIsSatisfied()
     mockEndpoint2.assertIsSatisfied()
 
-    camelContext.shutdown()
+    camelContext.shutdown() must not(throwA[Exception])
 
   }
 }

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
@@ -9,6 +9,7 @@
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.test.camel
+import io.xtech.babel.camel.mock._
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
 import org.apache.camel.component.mock.MockEndpoint
 import org.specs2.mutable.SpecificationWithJUnit
@@ -43,10 +44,10 @@ class MulticastSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint1 = camelContext.mockEndpoint({output1})
-    val mockEndpoint2 = camelContext.mockEndpoint({output2})
-    val mockEndpoint3 = camelContext.mockEndpoint({output3})
-    val mockEndpoint4 = camelContext.mockEndpoint({output4})
+    val mockEndpoint1 = camelContext.mockEndpoint("output1")
+    val mockEndpoint2 = camelContext.mockEndpoint("output2")
+    val mockEndpoint3 = camelContext.mockEndpoint("output3")
+    val mockEndpoint4 = camelContext.mockEndpoint("output4")
 
     mockEndpoint1.expectedBodiesReceived("test")
     mockEndpoint2.expectedBodiesReceived("test")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/MulticastSpec.scala
@@ -43,10 +43,10 @@ class MulticastSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-    val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-    val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-    val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
+    val mockEndpoint1 = camelContext.mockEndpoint({output1})
+    val mockEndpoint2 = camelContext.mockEndpoint({output2})
+    val mockEndpoint3 = camelContext.mockEndpoint({output3})
+    val mockEndpoint4 = camelContext.mockEndpoint({output4})
 
     mockEndpoint1.expectedBodiesReceived("test")
     mockEndpoint2.expectedBodiesReceived("test")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RecipientListSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RecipientListSpec.scala
@@ -9,6 +9,7 @@
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.builder.RouteBuilder
+import io.xtech.babel.camel.mock._
 import io.xtech.babel.camel.test.camel
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder, ValueBuilder }
 import org.apache.camel.component.mock.MockEndpoint
@@ -41,10 +42,10 @@ class RecipientListSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint1 = camelContext.mockEndpoint({output1})
-    val mockEndpoint2 = camelContext.mockEndpoint({output2})
-    val mockEndpoint3 = camelContext.mockEndpoint({output3})
-    val mockEndpoint4 = camelContext.mockEndpoint({output4})
+    val mockEndpoint1 = camelContext.mockEndpoint("output1")
+    val mockEndpoint2 = camelContext.mockEndpoint("output2")
+    val mockEndpoint3 = camelContext.mockEndpoint("output3")
+    val mockEndpoint4 = camelContext.mockEndpoint("output4")
 
     mockEndpoint1.expectedBodiesReceived("test")
     mockEndpoint2.expectedBodiesReceived("test")
@@ -94,10 +95,10 @@ class RecipientListSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint1 = camelContext.mockEndpoint({output1})
-    val mockEndpoint2 = camelContext.mockEndpoint({output2})
-    val mockEndpoint3 = camelContext.mockEndpoint({output3})
-    val mockEndpoint4 = camelContext.mockEndpoint({output4})
+    val mockEndpoint1 = camelContext.mockEndpoint("output1")
+    val mockEndpoint2 = camelContext.mockEndpoint("output2")
+    val mockEndpoint3 = camelContext.mockEndpoint("output3")
+    val mockEndpoint4 = camelContext.mockEndpoint("output4")
 
     mockEndpoint1.expectedBodiesReceived("test")
     mockEndpoint2.expectedBodiesReceived("test")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RecipientListSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RecipientListSpec.scala
@@ -41,10 +41,10 @@ class RecipientListSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-    val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-    val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-    val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
+    val mockEndpoint1 = camelContext.mockEndpoint({output1})
+    val mockEndpoint2 = camelContext.mockEndpoint({output2})
+    val mockEndpoint3 = camelContext.mockEndpoint({output3})
+    val mockEndpoint4 = camelContext.mockEndpoint({output4})
 
     mockEndpoint1.expectedBodiesReceived("test")
     mockEndpoint2.expectedBodiesReceived("test")
@@ -94,10 +94,10 @@ class RecipientListSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-    val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-    val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-    val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
+    val mockEndpoint1 = camelContext.mockEndpoint({output1})
+    val mockEndpoint2 = camelContext.mockEndpoint({output2})
+    val mockEndpoint3 = camelContext.mockEndpoint({output3})
+    val mockEndpoint4 = camelContext.mockEndpoint({output4})
 
     mockEndpoint1.expectedBodiesReceived("test")
     mockEndpoint2.expectedBodiesReceived("test")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RequireAsSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RequireAsSpec.scala
@@ -49,7 +49,7 @@ class RequireAsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint(mockProducer)
 
       //#doc:babel-camel-requireAs
       val producer = camelContext.createProducerTemplate()
@@ -74,7 +74,7 @@ class RequireAsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint(mockProducer)
 
       //#doc:babel-camel-requireAs-exception
       val producer = camelContext.createProducerTemplate()
@@ -94,7 +94,7 @@ class RequireAsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint(mockProducer)
 
       val b: B = B("bla")
       val a: A = B("bla")
@@ -117,7 +117,7 @@ class RequireAsSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint(mockProducer)
 
       mockEndpoint.expectedBodiesReceived(42: java.lang.Integer)
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RequireAsSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/RequireAsSpec.scala
@@ -12,6 +12,7 @@ import io.xtech.babel.camel.RequireAsSpec.{ A, B }
 import io.xtech.babel.camel.test.camel
 import org.apache.camel.CamelExecutionException
 import org.apache.camel.component.mock.MockEndpoint
+import io.xtech.babel.camel.mock._
 import org.specs2.mutable.SpecificationWithJUnit
 
 object RequireAsSpec {
@@ -27,7 +28,7 @@ object RequireAsSpec {
 class RequireAsSpec extends SpecificationWithJUnit {
 
   private val directConsumer = "direct:input"
-  private val mockProducer = "mock:output"
+  private val mockProducer = "output"
 
   sequential
 
@@ -42,14 +43,14 @@ class RequireAsSpec extends SpecificationWithJUnit {
         //Input Message bodies should be of type String
         //  or would throw an Exception
         from(directConsumer).requireAs[String].
-          processBody(_ + "4").to(mockProducer)
+          processBody(_ + "4").to(s"mock:$mockProducer")
       }
       //#doc:babel-camel-requireAs
       routeDef.addRoutesToCamelContext(camelContext)
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint(mockProducer)
+      val mockEndpoint = camelContext.mockEndpoint(mockProducer)
 
       //#doc:babel-camel-requireAs
       val producer = camelContext.createProducerTemplate()
@@ -67,14 +68,14 @@ class RequireAsSpec extends SpecificationWithJUnit {
         //no input Message may satisfies both type constraints,
         //   thus any message sent would throw an Exception.
         from(directConsumer).requireAs[String].requireAs[Int].
-          to(mockProducer)
+          to(s"mock:$mockProducer")
       }
       //#doc:babel-camel-requireAs-exception
       routeDef.addRoutesToCamelContext(camelContext)
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint(mockProducer)
+      val mockEndpoint = camelContext.mockEndpoint(mockProducer)
 
       //#doc:babel-camel-requireAs-exception
       val producer = camelContext.createProducerTemplate()
@@ -88,13 +89,13 @@ class RequireAsSpec extends SpecificationWithJUnit {
       import io.xtech.babel.camel.builder.RouteBuilder
 
       val routeDef = new RouteBuilder {
-        from(directConsumer).requireAs[A].to(mockProducer)
+        from(directConsumer).requireAs[A].to(s"mock:$mockProducer")
       }
       routeDef.addRoutesToCamelContext(camelContext)
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint(mockProducer)
+      val mockEndpoint = camelContext.mockEndpoint(mockProducer)
 
       val b: B = B("bla")
       val a: A = B("bla")
@@ -111,13 +112,13 @@ class RequireAsSpec extends SpecificationWithJUnit {
       import io.xtech.babel.camel.builder.RouteBuilder
 
       val routeDef = new RouteBuilder {
-        from(directConsumer).requireAs[Int].processBody((i: Int) => i).to(mockProducer)
+        from(directConsumer).requireAs[Int].processBody((i: Int) => i).to(s"mock:$mockProducer")
       }
       routeDef.addRoutesToCamelContext(camelContext)
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint(mockProducer)
+      val mockEndpoint = camelContext.mockEndpoint(mockProducer)
 
       mockEndpoint.expectedBodiesReceived(42: java.lang.Integer)
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitAggregateSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitAggregateSpec.scala
@@ -62,16 +62,16 @@ class SplitAggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel1").asInstanceOf[MockEndpoint]
-    val mockBabel2 = camelContext.getEndpoint("mock:babel2").asInstanceOf[MockEndpoint]
-    val mockBabel3 = camelContext.getEndpoint("mock:babel3").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel1")
+    val mockBabel2 = camelContext.mockEndoint("mock:babel2")
+    val mockBabel3 = camelContext.mockEndoint("mock:babel3")
     mockBabel1.expectedBodiesReceived("1", "2", "3")
     mockBabel2.expectedBodiesReceived("2", "3", "4")
     mockBabel3.expectedBodiesReceived("2,3,4")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
-    val mockCamel3 = camelContext.getEndpoint("mock:camel3").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamel3 = camelContext.mockEndoint("mock:camel3")
     mockCamel1.expectedBodiesReceived("1", "2", "3")
     mockCamel2.expectedBodiesReceived("2", "3", "4")
     mockCamel3.expectedBodiesReceived("2,3,4")
@@ -133,16 +133,16 @@ class SplitAggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel1").asInstanceOf[MockEndpoint]
-    val mockBabel2 = camelContext.getEndpoint("mock:babel2").asInstanceOf[MockEndpoint]
-    val mockBabel3 = camelContext.getEndpoint("mock:babel3").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel1")
+    val mockBabel2 = camelContext.mockEndoint("mock:babel2")
+    val mockBabel3 = camelContext.mockEndoint("mock:babel3")
     mockBabel1.expectedBodiesReceived("1", "2", "3")
     mockBabel2.expectedBodiesReceived("2", "3", "4")
     mockBabel3.expectedBodiesReceived("1,2,3,4")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
-    val mockCamel3 = camelContext.getEndpoint("mock:camel3").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamel3 = camelContext.mockEndoint("mock:camel3")
     mockCamel1.expectedBodiesReceived("1", "2", "3")
     mockCamel2.expectedBodiesReceived("2", "3", "4")
     mockCamel3.expectedBodiesReceived("1,2,3,4")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitAggregateSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitAggregateSpec.scala
@@ -14,6 +14,7 @@ import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.processor.aggregate.AggregationStrategy
 import org.apache.camel.{ Exchange, Processor }
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class SplitAggregateSpec extends SpecificationWithJUnit {
   sequential
@@ -62,16 +63,16 @@ class SplitAggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel1")
-    val mockBabel2 = camelContext.mockEndoint("mock:babel2")
-    val mockBabel3 = camelContext.mockEndoint("mock:babel3")
+    val mockBabel1 = camelContext.mockEndpoint("babel1")
+    val mockBabel2 = camelContext.mockEndpoint("babel2")
+    val mockBabel3 = camelContext.mockEndpoint("babel3")
     mockBabel1.expectedBodiesReceived("1", "2", "3")
     mockBabel2.expectedBodiesReceived("2", "3", "4")
     mockBabel3.expectedBodiesReceived("2,3,4")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
-    val mockCamel3 = camelContext.mockEndoint("mock:camel3")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
+    val mockCamel3 = camelContext.mockEndpoint("camel3")
     mockCamel1.expectedBodiesReceived("1", "2", "3")
     mockCamel2.expectedBodiesReceived("2", "3", "4")
     mockCamel3.expectedBodiesReceived("2,3,4")
@@ -133,16 +134,16 @@ class SplitAggregateSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel1")
-    val mockBabel2 = camelContext.mockEndoint("mock:babel2")
-    val mockBabel3 = camelContext.mockEndoint("mock:babel3")
+    val mockBabel1 = camelContext.mockEndpoint("babel1")
+    val mockBabel2 = camelContext.mockEndpoint("babel2")
+    val mockBabel3 = camelContext.mockEndpoint("babel3")
     mockBabel1.expectedBodiesReceived("1", "2", "3")
     mockBabel2.expectedBodiesReceived("2", "3", "4")
     mockBabel3.expectedBodiesReceived("1,2,3,4")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
-    val mockCamel3 = camelContext.mockEndoint("mock:camel3")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
+    val mockCamel3 = camelContext.mockEndpoint("camel3")
     mockCamel1.expectedBodiesReceived("1", "2", "3")
     mockCamel2.expectedBodiesReceived("2", "3", "4")
     mockCamel3.expectedBodiesReceived("1,2,3,4")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitFilterSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitFilterSpec.scala
@@ -8,6 +8,7 @@
 
 package io.xtech.babel.camel
 
+import io.xtech.babel.camel.mock.Mock
 import io.xtech.babel.camel.test.camel
 import io.xtech.babel.fish.RouteDefinitionException
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
@@ -46,8 +47,8 @@ class SplitFilterSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val mockCamel = camelContext.getEndpoint("mock:camel").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockCamel = camelContext.mockEndpoint({camel})
 
       mockEndpoint.expectedBodiesReceived("true")
       mockCamel.expectedBodiesReceived("true")
@@ -88,10 +89,8 @@ class SplitFilterSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-      val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-      val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-      val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val mockCamel = camelContext.mockEndoint("mock:camel")
 
       mockEndpoint1.expectedBodiesReceived("true")
       mockEndpoint2.expectedBodiesReceived("true")
@@ -112,14 +111,13 @@ class SplitFilterSpec extends SpecificationWithJUnit {
 
       import io.xtech.babel.camel.builder.RouteBuilder
 
-      val routeDef = new RouteBuilder {
+      val routeDef = new RouteBuilder with Mock {
         from("direct:input").as[String]
           //split the message base on its body using the comma
           .splitBody(_.split(",").iterator)
           //which creates several messages
           .filter(msg => msg.body.exists(body => body.contains("true")))
-          //required as keyword to recover the type
-          .to("mock:output").as[String]
+          .mock("output")
           //split the message base on its body using the spaces
           .splitBody(_.split(" ").iterator)
           .filter(msg => msg.body.exists(body => body == "false")).to("mock:false")
@@ -139,10 +137,10 @@ class SplitFilterSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
-      val mockEndEndpoint = camelContext.getEndpoint("mock:false").asInstanceOf[MockEndpoint]
-      val mockCamel = camelContext.getEndpoint("mock:camel").asInstanceOf[MockEndpoint]
-      val mockEndCamel = camelContext.getEndpoint("mock:camelfalse").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndEndpoint = camelContext.mockEndpoint({false})
+      val mockCamel = camelContext.mockEndpoint({camel})
+      val mockEndCamel = camelContext.mockEndpoint({camelfalse})
 
       mockEndpoint.expectedBodiesReceived("true false")
       mockEndEndpoint.expectedBodiesReceived("false")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitFilterSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitFilterSpec.scala
@@ -14,6 +14,7 @@ import io.xtech.babel.fish.RouteDefinitionException
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
 import org.apache.camel.component.mock.MockEndpoint
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class SplitFilterSpec extends SpecificationWithJUnit {
   "split and filter" should {
@@ -47,8 +48,8 @@ class SplitFilterSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
-      val mockCamel = camelContext.mockEndpoint({camel})
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val mockCamel = camelContext.mockEndpoint("camel")
 
       mockEndpoint.expectedBodiesReceived("true")
       mockCamel.expectedBodiesReceived("true")
@@ -89,8 +90,10 @@ class SplitFilterSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
-      val mockCamel = camelContext.mockEndoint("mock:camel")
+      val mockEndpoint1 = camelContext.mockEndpoint("output1")
+      val mockEndpoint2 = camelContext.mockEndpoint("output2")
+      val mockCamel1 = camelContext.mockEndpoint("camel1")
+      val mockCamel2 = camelContext.mockEndpoint("camel2")
 
       mockEndpoint1.expectedBodiesReceived("true")
       mockEndpoint2.expectedBodiesReceived("true")
@@ -137,10 +140,10 @@ class SplitFilterSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
-      val mockEndEndpoint = camelContext.mockEndpoint({false})
-      val mockCamel = camelContext.mockEndpoint({camel})
-      val mockEndCamel = camelContext.mockEndpoint({camelfalse})
+      val mockEndpoint = camelContext.mockEndpoint("output")
+      val mockEndEndpoint = camelContext.mockEndpoint("false")
+      val mockCamel = camelContext.mockEndpoint("camel")
+      val mockEndCamel = camelContext.mockEndpoint("camelfalse")
 
       mockEndpoint.expectedBodiesReceived("true false")
       mockEndEndpoint.expectedBodiesReceived("false")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitSpec.scala
@@ -15,6 +15,7 @@ import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.processor.aggregate.AggregationStrategy
 import org.apache.camel.{ Exchange, Processor }
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class SplitSpec extends SpecificationWithJUnit {
   sequential
@@ -44,11 +45,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel")
+    val mockBabel1 = camelContext.mockEndpoint("babel")
     mockBabel1.expectedBodiesReceived("1", "2", "3")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
     mockCamel1.expectedBodiesReceived("1", "2", "3")
     mockCamel2.expectedBodiesReceived("1,2,3")
 
@@ -93,11 +94,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel")
+    val mockBabel1 = camelContext.mockEndpoint("babel")
     mockBabel1.expectedBodiesReceived("1", "3")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
     mockCamel1.expectedBodiesReceived("1", "3")
     mockCamel2.expectedBodiesReceived()
 
@@ -151,15 +152,15 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel")
-    val mockBabelafter = camelContext.mockEndoint("mock:after")
-    val mockBabelInner = camelContext.mockEndoint("mock:babelInner")
+    val mockBabel1 = camelContext.mockEndpoint("babel")
+    val mockBabelafter = camelContext.mockEndpoint("after")
+    val mockBabelInner = camelContext.mockEndpoint("babelInner")
     mockBabel1.expectedBodiesReceived()
     mockBabelInner.expectedBodiesReceived("1", "2")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
-    val mockCamelInner = camelContext.mockEndoint("mock:camelInner")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
+    val mockCamelInner = camelContext.mockEndpoint("camelInner")
     mockCamel1.expectedBodiesReceived("1")
     mockCamel2.expectedBodiesReceived()
     mockCamelInner.expectedBodiesReceived("1", "2")
@@ -216,15 +217,15 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel")
-    val mockBabelafter = camelContext.mockEndoint("mock:after")
-    val mockBabelInner = camelContext.mockEndoint("mock:babelInner")
+    val mockBabel1 = camelContext.mockEndpoint("babel")
+    val mockBabelafter = camelContext.mockEndpoint("after")
+    val mockBabelInner = camelContext.mockEndpoint("babelInner")
     mockBabel1.expectedBodiesReceived()
     mockBabelInner.expectedBodiesReceived("1", "2")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
-    val mockCamelInner = camelContext.mockEndoint("mock:camelInner")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
+    val mockCamelInner = camelContext.mockEndpoint("camelInner")
     mockCamel1.expectedBodiesReceived("1")
     mockCamel2.expectedBodiesReceived()
     mockCamelInner.expectedBodiesReceived("1", "2")
@@ -272,11 +273,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel")
+    val mockBabel1 = camelContext.mockEndpoint("babel")
     mockBabel1.expectedBodiesReceived("1")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
     mockCamel1.expectedBodiesReceived("1")
     mockCamel2.expectedBodiesReceived()
 
@@ -321,11 +322,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.mockEndoint("mock:babel")
+    val mockBabel1 = camelContext.mockEndpoint("babel")
     mockBabel1.expectedBodiesReceived("1", "3")
 
-    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
-    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamel1 = camelContext.mockEndpoint("camel1")
+    val mockCamel2 = camelContext.mockEndpoint("camel2")
     mockCamel1.expectedBodiesReceived("1", "3")
     mockCamel2.expectedBodiesReceived()
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/SplitSpec.scala
@@ -44,11 +44,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel")
     mockBabel1.expectedBodiesReceived("1", "2", "3")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
     mockCamel1.expectedBodiesReceived("1", "2", "3")
     mockCamel2.expectedBodiesReceived("1,2,3")
 
@@ -93,11 +93,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel")
     mockBabel1.expectedBodiesReceived("1", "3")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
     mockCamel1.expectedBodiesReceived("1", "3")
     mockCamel2.expectedBodiesReceived()
 
@@ -151,15 +151,15 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel").asInstanceOf[MockEndpoint]
-    val mockBabelafter = camelContext.getEndpoint("mock:after").asInstanceOf[MockEndpoint]
-    val mockBabelInner = camelContext.getEndpoint("mock:babelInner").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel")
+    val mockBabelafter = camelContext.mockEndoint("mock:after")
+    val mockBabelInner = camelContext.mockEndoint("mock:babelInner")
     mockBabel1.expectedBodiesReceived()
     mockBabelInner.expectedBodiesReceived("1", "2")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
-    val mockCamelInner = camelContext.getEndpoint("mock:camelInner").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamelInner = camelContext.mockEndoint("mock:camelInner")
     mockCamel1.expectedBodiesReceived("1")
     mockCamel2.expectedBodiesReceived()
     mockCamelInner.expectedBodiesReceived("1", "2")
@@ -216,15 +216,15 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel").asInstanceOf[MockEndpoint]
-    val mockBabelafter = camelContext.getEndpoint("mock:after").asInstanceOf[MockEndpoint]
-    val mockBabelInner = camelContext.getEndpoint("mock:babelInner").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel")
+    val mockBabelafter = camelContext.mockEndoint("mock:after")
+    val mockBabelInner = camelContext.mockEndoint("mock:babelInner")
     mockBabel1.expectedBodiesReceived()
     mockBabelInner.expectedBodiesReceived("1", "2")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
-    val mockCamelInner = camelContext.getEndpoint("mock:camelInner").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
+    val mockCamelInner = camelContext.mockEndoint("mock:camelInner")
     mockCamel1.expectedBodiesReceived("1")
     mockCamel2.expectedBodiesReceived()
     mockCamelInner.expectedBodiesReceived("1", "2")
@@ -272,11 +272,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel")
     mockBabel1.expectedBodiesReceived("1")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
     mockCamel1.expectedBodiesReceived("1")
     mockCamel2.expectedBodiesReceived()
 
@@ -321,11 +321,11 @@ class SplitSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockBabel1 = camelContext.getEndpoint("mock:babel").asInstanceOf[MockEndpoint]
+    val mockBabel1 = camelContext.mockEndoint("mock:babel")
     mockBabel1.expectedBodiesReceived("1", "3")
 
-    val mockCamel1 = camelContext.getEndpoint("mock:camel1").asInstanceOf[MockEndpoint]
-    val mockCamel2 = camelContext.getEndpoint("mock:camel2").asInstanceOf[MockEndpoint]
+    val mockCamel1 = camelContext.mockEndoint("mock:camel1")
+    val mockCamel2 = camelContext.mockEndoint("mock:camel2")
     mockCamel1.expectedBodiesReceived("1", "3")
     mockCamel2.expectedBodiesReceived()
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/ThrottlerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/ThrottlerSpec.scala
@@ -13,6 +13,7 @@ import io.xtech.babel.camel.test.camel
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
 import org.apache.camel.component.mock.MockEndpoint
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class ThrottlerSpec extends SpecificationWithJUnit {
   sequential
@@ -44,7 +45,7 @@ class ThrottlerSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint = camelContext.mockEndpoint({output})
+    val mockEndpoint = camelContext.mockEndpoint("output")
 
     mockEndpoint.setExpectedMessageCount(msgs)
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/ThrottlerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/ThrottlerSpec.scala
@@ -44,7 +44,7 @@ class ThrottlerSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+    val mockEndpoint = camelContext.mockEndpoint({output})
 
     mockEndpoint.setExpectedMessageCount(msgs)
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransactionSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransactionSpec.scala
@@ -191,7 +191,7 @@ class TransactionSpec extends CachedBabelSpringSpecification {
 
       jdbcTemplate.execute("delete from users")
 
-      val routeDef = new RouteBuilder with Mock{
+      val routeDef = new RouteBuilder with Mock {
         var tries = 3
 
         handle(_.transactionErrorHandler.maximumRedeliveries(tries))

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransactionSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransactionSpec.scala
@@ -11,6 +11,7 @@ package io.xtech.babel.camel
 import javax.sql.DataSource
 
 import io.xtech.babel.camel.TransactionSpec.TransactionTestContext
+import io.xtech.babel.camel.mock.Mock
 import io.xtech.babel.camel.test.CachedBabelSpringSpecification
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.model.ModelCamelContext
@@ -148,15 +149,15 @@ class TransactionSpec extends CachedBabelSpringSpecification {
 
       jdbcTemplate.execute("delete from users")
 
-      val routeDef = new RouteBuilder {
+      val routeDef = new RouteBuilder with Mock {
         var tries = 3
 
         from("direct:input6")
           .handle(_.transactionErrorHandler.maximumRedeliveries(tries))
           .transacted
           .to("sql:insert into users (name) values (#)?dataSourceRef=dataSource")
-          .to("mock:in-the-middle-route")
-          .as[String].process(m => {
+          .mock("in-the-middle-route")
+          .process(m => {
             tries -= 1
             if (tries != 0) throw new Exception("Expected exception") else m
           })
@@ -190,7 +191,7 @@ class TransactionSpec extends CachedBabelSpringSpecification {
 
       jdbcTemplate.execute("delete from users")
 
-      val routeDef = new RouteBuilder {
+      val routeDef = new RouteBuilder with Mock{
         var tries = 3
 
         handle(_.transactionErrorHandler.maximumRedeliveries(tries))
@@ -198,8 +199,8 @@ class TransactionSpec extends CachedBabelSpringSpecification {
         from("direct:input7")
           .transacted
           .to("sql:insert into users (name) values (#)?dataSourceRef=dataSource")
-          .to("mock:in-the-middle-route-builder")
-          .as[String].process(m => {
+          .mock("in-the-middle-route-builder")
+          .process(m => {
             tries -= 1;
             if (tries != 0) throw new Exception("Expected exception") else m
           })

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransformerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransformerSpec.scala
@@ -12,6 +12,7 @@ import io.xtech.babel.camel.test.camel
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.impl.SimpleRegistry
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class TestBean {
 
@@ -47,7 +48,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -81,7 +82,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -112,7 +113,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -136,7 +137,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -167,7 +168,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -191,7 +192,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.mockEndoint("mock:output")
+      val mockEndpoint = camelContext.mockEndpoint("output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransformerSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/TransformerSpec.scala
@@ -47,7 +47,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -81,7 +81,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -112,7 +112,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -136,7 +136,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -167,7 +167,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 
@@ -191,7 +191,7 @@ class TransformerSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint = camelContext.getEndpoint(mockProducer).asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndoint("mock:output")
 
       mockEndpoint.expectedBodiesReceived("testbla")
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
@@ -12,6 +12,7 @@ import io.xtech.babel.camel.test.camel
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
 import org.apache.camel.component.mock.MockEndpoint
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class WireTapSpec extends SpecificationWithJUnit {
   sequential
@@ -52,10 +53,10 @@ class WireTapSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpointB = camelContext.mockEndoint("mock:output-babel")
-    val mockEndpointBT = camelContext.mockEndoint("mock:babel-tap")
-    val mockEndpointC = camelContext.mockEndoint("mock:output-camel")
-    val mockEndpointCT = camelContext.mockEndoint("mock:camel-tap")
+    val mockEndpointB = camelContext.mockEndpoint("output-babel")
+    val mockEndpointBT = camelContext.mockEndpoint("babel-tap")
+    val mockEndpointC = camelContext.mockEndpoint("output-camel")
+    val mockEndpointCT = camelContext.mockEndpoint("camel-tap")
 
     mockEndpointB.expectedBodiesReceived(testMessage, wireTapMessage)
     mockEndpointBT.expectedBodiesReceived(wireTapMessage)

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
@@ -52,10 +52,10 @@ class WireTapSpec extends SpecificationWithJUnit {
 
     camelContext.start()
 
-    val mockEndpointB = camelContext.getEndpoint("mock:output-babel").asInstanceOf[MockEndpoint]
-    val mockEndpointBT = camelContext.getEndpoint("mock:babel-tap").asInstanceOf[MockEndpoint]
-    val mockEndpointC = camelContext.getEndpoint("mock:output-camel").asInstanceOf[MockEndpoint]
-    val mockEndpointCT = camelContext.getEndpoint("mock:camel-tap").asInstanceOf[MockEndpoint]
+    val mockEndpointB = camelContext.mockEndoint("mock:output-babel")
+    val mockEndpointBT = camelContext.mockEndoint("mock:babel-tap")
+    val mockEndpointC = camelContext.mockEndoint("mock:output-camel")
+    val mockEndpointCT = camelContext.mockEndoint("mock:camel-tap")
 
     mockEndpointB.expectedBodiesReceived(testMessage, wireTapMessage)
     mockEndpointBT.expectedBodiesReceived(wireTapMessage)

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/XMLSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/XMLSpec.scala
@@ -13,6 +13,7 @@ import io.xtech.babel.camel.test.camel
 import org.apache.camel.builder.xml.XPathBuilder
 import org.apache.camel.component.mock.MockEndpoint
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class XMLSpec extends SpecificationWithJUnit {
   sequential
@@ -34,7 +35,7 @@ class XMLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
       mockEndpoint.expectedMessageCount(7)
 
       producer.sendBody("direct:input",
@@ -65,7 +66,7 @@ class XMLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.mockEndpoint({output})
+      val mockEndpoint = camelContext.mockEndpoint("output")
       mockEndpoint.expectedMessageCount(1)
 
       producer.sendBody("direct:input",
@@ -105,13 +106,13 @@ class XMLSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint1 = camelContext.mockEndpoint({output1})
+      val mockEndpoint1 = camelContext.mockEndpoint("output1")
       mockEndpoint1.expectedMessageCount(1)
 
-      val mockEndpoint2 = camelContext.mockEndpoint({output2})
+      val mockEndpoint2 = camelContext.mockEndpoint("output2")
       mockEndpoint2.expectedMessageCount(1)
 
-      val mockEndpoint3 = camelContext.mockEndpoint({output3})
+      val mockEndpoint3 = camelContext.mockEndpoint("output3")
       mockEndpoint3.expectedMessageCount(1)
 
       val producer = camelContext.createProducerTemplate()

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/XMLSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/XMLSpec.scala
@@ -34,7 +34,7 @@ class XMLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
       mockEndpoint.expectedMessageCount(7)
 
       producer.sendBody("direct:input",
@@ -65,7 +65,7 @@ class XMLSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+      val mockEndpoint = camelContext.mockEndpoint({output})
       mockEndpoint.expectedMessageCount(1)
 
       producer.sendBody("direct:input",
@@ -105,13 +105,13 @@ class XMLSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
+      val mockEndpoint1 = camelContext.mockEndpoint({output1})
       mockEndpoint1.expectedMessageCount(1)
 
-      val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
+      val mockEndpoint2 = camelContext.mockEndpoint({output2})
       mockEndpoint2.expectedMessageCount(1)
 
-      val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
+      val mockEndpoint3 = camelContext.mockEndpoint({output3})
       mockEndpoint3.expectedMessageCount(1)
 
       val producer = camelContext.createProducerTemplate()

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/ComplexChoiceSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/ComplexChoiceSpec.scala
@@ -70,15 +70,15 @@ class ComplexChoiceSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-      val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-      val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-      val mockEndpoint5 = camelContext.getEndpoint("mock:output5").asInstanceOf[MockEndpoint]
+      val mockEndpoint1 = camelContext.mockEndpoint({output1})
+      val mockEndpoint2 = camelContext.mockEndpoint({output2})
+      val mockEndpoint3 = camelContext.mockEndpoint({output3})
+      val mockEndpoint5 = camelContext.mockEndpoint({output5})
 
-      val mockCamelEndpoint1 = camelContext.getEndpoint("mock:camelout1").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint2 = camelContext.getEndpoint("mock:camelout2").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint3 = camelContext.getEndpoint("mock:camelout3").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint5 = camelContext.getEndpoint("mock:camelout5").asInstanceOf[MockEndpoint]
+      val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
+      val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
+      val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
+      val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
 
       mockEndpoint1.expectedBodiesReceived("1done")
       mockCamelEndpoint1.expectedBodiesReceived("1done")
@@ -164,19 +164,19 @@ class ComplexChoiceSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-      val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-      val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-      val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
-      val mockEndpoint5 = camelContext.getEndpoint("mock:output5").asInstanceOf[MockEndpoint]
-      val mockEndpoint6 = camelContext.getEndpoint("mock:output6").asInstanceOf[MockEndpoint]
+      val mockEndpoint1 = camelContext.mockEndpoint({output1})
+      val mockEndpoint2 = camelContext.mockEndpoint({output2})
+      val mockEndpoint3 = camelContext.mockEndpoint({output3})
+      val mockEndpoint4 = camelContext.mockEndpoint({output4})
+      val mockEndpoint5 = camelContext.mockEndpoint({output5})
+      val mockEndpoint6 = camelContext.mockEndpoint({output6})
 
-      val mockCamelEndpoint1 = camelContext.getEndpoint("mock:camelout1").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint2 = camelContext.getEndpoint("mock:camelout2").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint3 = camelContext.getEndpoint("mock:camelout3").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint4 = camelContext.getEndpoint("mock:camelout4").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint5 = camelContext.getEndpoint("mock:camelout5").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint6 = camelContext.getEndpoint("mock:camelout6").asInstanceOf[MockEndpoint]
+      val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
+      val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
+      val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
+      val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
+      val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
+      val mockCamelEndpoint6 = camelContext.mockEndpoint({camelout6})
 
       mockCamelEndpoint1.expectedBodiesReceived("1done")
       mockEndpoint1.expectedBodiesReceived("1done")
@@ -263,15 +263,15 @@ class ComplexChoiceSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-      val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-      val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
-      val mockEndpoint5 = camelContext.getEndpoint("mock:output5").asInstanceOf[MockEndpoint]
+      val mockEndpoint2 = camelContext.mockEndpoint({output2})
+      val mockEndpoint3 = camelContext.mockEndpoint({output3})
+      val mockEndpoint4 = camelContext.mockEndpoint({output4})
+      val mockEndpoint5 = camelContext.mockEndpoint({output5})
 
-      val mockCamelEndpoint2 = camelContext.getEndpoint("mock:camelout2").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint3 = camelContext.getEndpoint("mock:camelout3").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint4 = camelContext.getEndpoint("mock:camelout4").asInstanceOf[MockEndpoint]
-      val mockCamelEndpoint5 = camelContext.getEndpoint("mock:camelout5").asInstanceOf[MockEndpoint]
+      val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
+      val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
+      val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
+      val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
 
       mockEndpoint2.expectedBodiesReceived("2done")
       mockCamelEndpoint2.expectedBodiesReceived("2done")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/ComplexChoiceSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/ComplexChoiceSpec.scala
@@ -16,6 +16,7 @@ import org.apache.camel.{ Exchange, Predicate, Processor }
 import org.specs2.mutable.SpecificationWithJUnit
 
 import scala.collection.JavaConverters._
+import io.xtech.babel.camel.mock._
 
 class ComplexChoiceSpec extends SpecificationWithJUnit {
   "a choice" should {
@@ -70,15 +71,15 @@ class ComplexChoiceSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint1 = camelContext.mockEndpoint({output1})
-      val mockEndpoint2 = camelContext.mockEndpoint({output2})
-      val mockEndpoint3 = camelContext.mockEndpoint({output3})
-      val mockEndpoint5 = camelContext.mockEndpoint({output5})
+      val mockEndpoint1 = camelContext.mockEndpoint("output1")
+      val mockEndpoint2 = camelContext.mockEndpoint("output2")
+      val mockEndpoint3 = camelContext.mockEndpoint("output3")
+      val mockEndpoint5 = camelContext.mockEndpoint("output5")
 
-      val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
-      val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
-      val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
-      val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
+      val mockCamelEndpoint1 = camelContext.mockEndpoint("camelout1")
+      val mockCamelEndpoint2 = camelContext.mockEndpoint("camelout2")
+      val mockCamelEndpoint3 = camelContext.mockEndpoint("camelout3")
+      val mockCamelEndpoint5 = camelContext.mockEndpoint("camelout5")
 
       mockEndpoint1.expectedBodiesReceived("1done")
       mockCamelEndpoint1.expectedBodiesReceived("1done")
@@ -164,19 +165,19 @@ class ComplexChoiceSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint1 = camelContext.mockEndpoint({output1})
-      val mockEndpoint2 = camelContext.mockEndpoint({output2})
-      val mockEndpoint3 = camelContext.mockEndpoint({output3})
-      val mockEndpoint4 = camelContext.mockEndpoint({output4})
-      val mockEndpoint5 = camelContext.mockEndpoint({output5})
-      val mockEndpoint6 = camelContext.mockEndpoint({output6})
+      val mockEndpoint1 = camelContext.mockEndpoint("output1")
+      val mockEndpoint2 = camelContext.mockEndpoint("output2")
+      val mockEndpoint3 = camelContext.mockEndpoint("output3")
+      val mockEndpoint4 = camelContext.mockEndpoint("output4")
+      val mockEndpoint5 = camelContext.mockEndpoint("output5")
+      val mockEndpoint6 = camelContext.mockEndpoint("output6")
 
-      val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
-      val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
-      val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
-      val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
-      val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
-      val mockCamelEndpoint6 = camelContext.mockEndpoint({camelout6})
+      val mockCamelEndpoint1 = camelContext.mockEndpoint("camelout1")
+      val mockCamelEndpoint2 = camelContext.mockEndpoint("camelout2")
+      val mockCamelEndpoint3 = camelContext.mockEndpoint("camelout3")
+      val mockCamelEndpoint4 = camelContext.mockEndpoint("camelout4")
+      val mockCamelEndpoint5 = camelContext.mockEndpoint("camelout5")
+      val mockCamelEndpoint6 = camelContext.mockEndpoint("camelout6")
 
       mockCamelEndpoint1.expectedBodiesReceived("1done")
       mockEndpoint1.expectedBodiesReceived("1done")
@@ -263,15 +264,15 @@ class ComplexChoiceSpec extends SpecificationWithJUnit {
 
       val producer = camelContext.createProducerTemplate()
 
-      val mockEndpoint2 = camelContext.mockEndpoint({output2})
-      val mockEndpoint3 = camelContext.mockEndpoint({output3})
-      val mockEndpoint4 = camelContext.mockEndpoint({output4})
-      val mockEndpoint5 = camelContext.mockEndpoint({output5})
+      val mockEndpoint2 = camelContext.mockEndpoint("output2")
+      val mockEndpoint3 = camelContext.mockEndpoint("output3")
+      val mockEndpoint4 = camelContext.mockEndpoint("output4")
+      val mockEndpoint5 = camelContext.mockEndpoint("output5")
 
-      val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
-      val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
-      val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
-      val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
+      val mockCamelEndpoint2 = camelContext.mockEndpoint("camelout2")
+      val mockCamelEndpoint3 = camelContext.mockEndpoint("camelout3")
+      val mockCamelEndpoint4 = camelContext.mockEndpoint("camelout4")
+      val mockCamelEndpoint5 = camelContext.mockEndpoint("camelout5")
 
       mockEndpoint2.expectedBodiesReceived("2done")
       mockCamelEndpoint2.expectedBodiesReceived("2done")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/DemoSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/DemoSpec.scala
@@ -60,8 +60,8 @@ class DemoSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.getEndpoint("mock:database").asInstanceOf[MockEndpoint]
-    val mockEndpoint2 = camelContext.getEndpoint("mock:error").asInstanceOf[MockEndpoint]
+    val mockEndpoint1 = camelContext.mockEndpoint({database})
+    val mockEndpoint2 = camelContext.mockEndpoint({error})
 
     mockEndpoint1.expectedBodiesReceived("6")
     mockEndpoint2.expectedBodiesReceived("-1 is negative")
@@ -118,8 +118,8 @@ class DemoSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.getEndpoint("mock:database-camel-scala").asInstanceOf[MockEndpoint]
-    val mockEndpoint2 = camelContext.getEndpoint("mock:error-camel-scala").asInstanceOf[MockEndpoint]
+    val mockEndpoint1 = camelContext.mockEndoint("mock:database-camel-scala")
+    val mockEndpoint2 = camelContext.mockEndoint("mock:error-camel-scala")
 
     mockEndpoint1.expectedBodiesReceived("6")
     mockEndpoint2.expectedBodiesReceived("-1 is negative")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/DemoSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/DemoSpec.scala
@@ -15,6 +15,7 @@ import org.apache.camel.Exchange
 import org.apache.camel.component.mock.MockEndpoint
 import org.apache.camel.processor.aggregate.AggregationStrategy
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class DemoSpec extends SpecificationWithJUnit {
 
@@ -60,8 +61,8 @@ class DemoSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.mockEndpoint({database})
-    val mockEndpoint2 = camelContext.mockEndpoint({error})
+    val mockEndpoint1 = camelContext.mockEndpoint("database")
+    val mockEndpoint2 = camelContext.mockEndpoint("error")
 
     mockEndpoint1.expectedBodiesReceived("6")
     mockEndpoint2.expectedBodiesReceived("-1 is negative")
@@ -118,8 +119,8 @@ class DemoSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.mockEndoint("mock:database-camel-scala")
-    val mockEndpoint2 = camelContext.mockEndoint("mock:error-camel-scala")
+    val mockEndpoint1 = camelContext.mockEndpoint("database-camel-scala")
+    val mockEndpoint2 = camelContext.mockEndpoint("error-camel-scala")
 
     mockEndpoint1.expectedBodiesReceived("6")
     mockEndpoint2.expectedBodiesReceived("-1 is negative")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/SimpleChoiceSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/SimpleChoiceSpec.scala
@@ -78,17 +78,17 @@ class SimpleChoiceSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-    val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-    val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-    val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
-    val mockEndpoint5 = camelContext.getEndpoint("mock:output5").asInstanceOf[MockEndpoint]
+    val mockEndpoint1 = camelContext.mockEndpoint({output1})
+    val mockEndpoint2 = camelContext.mockEndpoint({output2})
+    val mockEndpoint3 = camelContext.mockEndpoint({output3})
+    val mockEndpoint4 = camelContext.mockEndpoint({output4})
+    val mockEndpoint5 = camelContext.mockEndpoint({output5})
 
-    val mockCamelEndpoint1 = camelContext.getEndpoint("mock:camelout1").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint2 = camelContext.getEndpoint("mock:camelout2").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint3 = camelContext.getEndpoint("mock:camelout3").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint4 = camelContext.getEndpoint("mock:camelout4").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint5 = camelContext.getEndpoint("mock:camelout5").asInstanceOf[MockEndpoint]
+    val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
+    val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
+    val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
+    val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
+    val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
 
     mockEndpoint1.expectedBodiesReceived("1done")
     mockCamelEndpoint1.expectedBodiesReceived("1done")
@@ -180,17 +180,17 @@ class SimpleChoiceSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.getEndpoint("mock:output1").asInstanceOf[MockEndpoint]
-    val mockEndpoint2 = camelContext.getEndpoint("mock:output2").asInstanceOf[MockEndpoint]
-    val mockEndpoint3 = camelContext.getEndpoint("mock:output3").asInstanceOf[MockEndpoint]
-    val mockEndpoint4 = camelContext.getEndpoint("mock:output4").asInstanceOf[MockEndpoint]
-    val mockEndpoint5 = camelContext.getEndpoint("mock:output5").asInstanceOf[MockEndpoint]
+    val mockEndpoint1 = camelContext.mockEndpoint({output1})
+    val mockEndpoint2 = camelContext.mockEndpoint({output2})
+    val mockEndpoint3 = camelContext.mockEndpoint({output3})
+    val mockEndpoint4 = camelContext.mockEndpoint({output4})
+    val mockEndpoint5 = camelContext.mockEndpoint({output5})
 
-    val mockCamelEndpoint1 = camelContext.getEndpoint("mock:camelout1").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint2 = camelContext.getEndpoint("mock:camelout2").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint3 = camelContext.getEndpoint("mock:camelout3").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint4 = camelContext.getEndpoint("mock:camelout4").asInstanceOf[MockEndpoint]
-    val mockCamelEndpoint5 = camelContext.getEndpoint("mock:camelout5").asInstanceOf[MockEndpoint]
+    val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
+    val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
+    val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
+    val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
+    val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
 
     mockEndpoint1.expectedBodiesReceived("1done")
     mockCamelEndpoint1.expectedBodiesReceived("1done")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/SimpleChoiceSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/choice/SimpleChoiceSpec.scala
@@ -11,11 +11,12 @@ package io.xtech.babel.camel.choice
 import io.xtech.babel.camel.builder.RouteBuilder
 import io.xtech.babel.camel.test.camel
 import org.apache.camel.builder.{ RouteBuilder => CRouteBuilder }
-import org.apache.camel.component.mock.MockEndpoint
+import io.xtech.babel.camel.mock._
 import org.apache.camel.{ Exchange, Predicate, Processor }
 import org.specs2.mutable.SpecificationWithJUnit
 
 import scala.collection.JavaConverters._
+import io.xtech.babel.camel.mock._
 
 class SimpleChoiceSpec extends SpecificationWithJUnit {
 
@@ -78,17 +79,17 @@ class SimpleChoiceSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.mockEndpoint({output1})
-    val mockEndpoint2 = camelContext.mockEndpoint({output2})
-    val mockEndpoint3 = camelContext.mockEndpoint({output3})
-    val mockEndpoint4 = camelContext.mockEndpoint({output4})
-    val mockEndpoint5 = camelContext.mockEndpoint({output5})
+    val mockEndpoint1 = camelContext.mockEndpoint("output1")
+    val mockEndpoint2 = camelContext.mockEndpoint("output2")
+    val mockEndpoint3 = camelContext.mockEndpoint("output3")
+    val mockEndpoint4 = camelContext.mockEndpoint("output4")
+    val mockEndpoint5 = camelContext.mockEndpoint("output5")
 
-    val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
-    val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
-    val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
-    val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
-    val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
+    val mockCamelEndpoint1 = camelContext.mockEndpoint("camelout1")
+    val mockCamelEndpoint2 = camelContext.mockEndpoint("camelout2")
+    val mockCamelEndpoint3 = camelContext.mockEndpoint("camelout3")
+    val mockCamelEndpoint4 = camelContext.mockEndpoint("camelout4")
+    val mockCamelEndpoint5 = camelContext.mockEndpoint("camelout5")
 
     mockEndpoint1.expectedBodiesReceived("1done")
     mockCamelEndpoint1.expectedBodiesReceived("1done")
@@ -180,17 +181,17 @@ class SimpleChoiceSpec extends SpecificationWithJUnit {
 
     val producer = camelContext.createProducerTemplate()
 
-    val mockEndpoint1 = camelContext.mockEndpoint({output1})
-    val mockEndpoint2 = camelContext.mockEndpoint({output2})
-    val mockEndpoint3 = camelContext.mockEndpoint({output3})
-    val mockEndpoint4 = camelContext.mockEndpoint({output4})
-    val mockEndpoint5 = camelContext.mockEndpoint({output5})
+    val mockEndpoint1 = camelContext.mockEndpoint("output1")
+    val mockEndpoint2 = camelContext.mockEndpoint("output2")
+    val mockEndpoint3 = camelContext.mockEndpoint("output3")
+    val mockEndpoint4 = camelContext.mockEndpoint("output4")
+    val mockEndpoint5 = camelContext.mockEndpoint("output5")
 
-    val mockCamelEndpoint1 = camelContext.mockEndpoint({camelout1})
-    val mockCamelEndpoint2 = camelContext.mockEndpoint({camelout2})
-    val mockCamelEndpoint3 = camelContext.mockEndpoint({camelout3})
-    val mockCamelEndpoint4 = camelContext.mockEndpoint({camelout4})
-    val mockCamelEndpoint5 = camelContext.mockEndpoint({camelout5})
+    val mockCamelEndpoint1 = camelContext.mockEndpoint("camelout1")
+    val mockCamelEndpoint2 = camelContext.mockEndpoint("camelout2")
+    val mockCamelEndpoint3 = camelContext.mockEndpoint("camelout3")
+    val mockCamelEndpoint4 = camelContext.mockEndpoint("camelout4")
+    val mockCamelEndpoint5 = camelContext.mockEndpoint("camelout5")
 
     mockEndpoint1.expectedBodiesReceived("1done")
     mockCamelEndpoint1.expectedBodiesReceived("1done")

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SamplePhilosophySpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SamplePhilosophySpec.scala
@@ -68,10 +68,10 @@ class SamplePhilosophySpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockLower = camelContext.getEndpoint("mock:lowercase").asInstanceOf[MockEndpoint]
+      val mockLower = camelContext.mockEndpoint({lowercase})
       mockLower.expectedBodiesReceived("h2g2")
 
-      val mockDouble = camelContext.getEndpoint("mock:double").asInstanceOf[MockEndpoint]
+      val mockDouble = camelContext.mockEndpoint({double})
       mockDouble.expectedBodiesReceived("42")
 
       val producer = camelContext.createProducerTemplate()
@@ -115,7 +115,7 @@ class SamplePhilosophySpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockTwitts = camelContext.getEndpoint("mock:twitts").asInstanceOf[MockEndpoint]
+      val mockTwitts = camelContext.mockEndpoint({twitts})
       mockTwitts.expectedBodiesReceived("h2g2")
 
       val producer = camelContext.createProducerTemplate()

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SamplePhilosophySpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SamplePhilosophySpec.scala
@@ -14,6 +14,7 @@ import io.xtech.babel.fish.NamingStrategy
 import io.xtech.babel.fish.model.StepDefinition
 import org.apache.camel.component.mock.MockEndpoint
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class SamplePhilosophySpec extends SpecificationWithJUnit {
 
@@ -68,10 +69,10 @@ class SamplePhilosophySpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockLower = camelContext.mockEndpoint({lowercase})
+      val mockLower = camelContext.mockEndpoint("lowercase")
       mockLower.expectedBodiesReceived("h2g2")
 
-      val mockDouble = camelContext.mockEndpoint({double})
+      val mockDouble = camelContext.mockEndpoint("double")
       mockDouble.expectedBodiesReceived("42")
 
       val producer = camelContext.createProducerTemplate()
@@ -115,7 +116,7 @@ class SamplePhilosophySpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockTwitts = camelContext.mockEndpoint({twitts})
+      val mockTwitts = camelContext.mockEndpoint("twitts")
       mockTwitts.expectedBodiesReceived("h2g2")
 
       val producer = camelContext.createProducerTemplate()

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SampleSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SampleSpec.scala
@@ -55,10 +55,10 @@ class SampleSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpointF = camelContext.getEndpoint("mock:france").asInstanceOf[MockEndpoint]
+      val mockEndpointF = camelContext.mockEndpoint({france})
       mockEndpointF.expectedBodiesReceived("F")
 
-      val mockEndpointCH = camelContext.getEndpoint("mock:switzerland").asInstanceOf[MockEndpoint]
+      val mockEndpointCH = camelContext.mockEndpoint({switzerland})
       mockEndpointCH.expectedBodiesReceived("CH")
 
       val producer = camelContext.createProducerTemplate()

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SampleSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/sample/SampleSpec.scala
@@ -13,6 +13,7 @@ import io.xtech.babel.camel.test.camel
 import io.xtech.babel.fish.model.Message
 import org.apache.camel.component.mock.MockEndpoint
 import org.specs2.mutable.SpecificationWithJUnit
+import io.xtech.babel.camel.mock._
 
 class SampleSpec extends SpecificationWithJUnit {
   sequential
@@ -55,10 +56,10 @@ class SampleSpec extends SpecificationWithJUnit {
 
       camelContext.start()
 
-      val mockEndpointF = camelContext.mockEndpoint({france})
+      val mockEndpointF = camelContext.mockEndpoint("france")
       mockEndpointF.expectedBodiesReceived("F")
 
-      val mockEndpointCH = camelContext.mockEndpoint({switzerland})
+      val mockEndpointCH = camelContext.mockEndpoint("switzerland")
       mockEndpointCH.expectedBodiesReceived("CH")
 
       val producer = camelContext.createProducerTemplate()

--- a/babel-camel/babel-camel-mock/pom.xml
+++ b/babel-camel/babel-camel-mock/pom.xml
@@ -35,13 +35,6 @@
             <version>${project.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>io.xtech.babel</groupId>
-            <artifactId>babel-camel-core</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>io.xtech.babel</groupId>

--- a/babel-camel/babel-camel-mock/src/main/scala/io/xtech/babel/camel/mock/MockDSL.scala
+++ b/babel-camel/babel-camel-mock/src/main/scala/io/xtech/babel/camel/mock/MockDSL.scala
@@ -10,10 +10,10 @@
 
 package io.xtech.babel.camel.mock
 
-import io.xtech.babel.camel.parsing.CamelParsing
 import io.xtech.babel.fish.model.StepDefinition
-import io.xtech.babel.fish.parsing.StepInformation
+import io.xtech.babel.fish.parsing.{ Parsing, StepInformation }
 import io.xtech.babel.fish.{ BaseDSL, DSL2BaseDSL }
+import org.apache.camel.builder.RouteBuilder
 import org.apache.camel.model.ProcessorDefinition
 import scala.collection.immutable
 import scala.language.implicitConversions
@@ -32,7 +32,7 @@ class MockDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) extends DSL2BaseDS
   def mock(endpointUri: String): BaseDSL[I] = MockDefinition(endpointUri)
 }
 
-trait Mock extends CamelParsing {
+trait Mock extends Parsing[RouteBuilder] {
 
   abstract override protected def steps: immutable.Seq[Process] = super.steps :+ parse
 

--- a/babel-camel/babel-camel-mock/src/test/scala/io/xtech/babel/camel/MockSpec.scala
+++ b/babel-camel/babel-camel-mock/src/test/scala/io/xtech/babel/camel/MockSpec.scala
@@ -38,7 +38,7 @@ class MockSpec extends SpecificationWithJUnit {
     camelContext.start()
 
     val mockEndpoint1 = camelContext.getMockEndpoint("output1")
-    val mockEndpoint2 = camelContext.getMockEndpoint("output2")
+    val mockEndpoint2 = camelContext.mockEndpoint("output2")
 
     mockEndpoint1.expectedBodiesReceived("test")
     mockEndpoint2.expectedBodiesReceived("TEST")

--- a/babel-camel/babel-camel-mock/src/test/scala/io/xtech/babel/camel/MockSpec.scala
+++ b/babel-camel/babel-camel-mock/src/test/scala/io/xtech/babel/camel/MockSpec.scala
@@ -1,0 +1,64 @@
+/*
+ *
+ *  Copyright 2010-2014 Crossing-Tech SA, EPFL QI-J, CH-1015 Lausanne, Switzerland.
+ *  All rights reserved.
+ *
+ * ==================================================================================
+ */
+
+package io.xtech.babel.camel
+
+import io.xtech.babel.camel.builder.RouteBuilder
+import io.xtech.babel.camel.mock._
+import org.apache.camel.impl.DefaultCamelContext
+import org.specs2.mutable.SpecificationWithJUnit
+
+class MockSpec extends SpecificationWithJUnit {
+  sequential
+
+  "extend the DSL with some sub DSL (mock)" in {
+
+
+    val camelContext = new DefaultCamelContext()
+
+    //#doc:babel-camel-mock
+    import io.xtech.babel.camel.mock._
+
+    //The Mock extension is added simply by
+    //  extending the RouteBuilder with
+    val routeDef = new RouteBuilder with Mock {
+      //the mock keyword is the same as typing
+      //  to("mock:output1")
+      from("direct:input").
+        requireAs[String].
+        mock("output1").
+        //the mock keyword keeps the same body type (here: String)
+        processBody(x => x.toUpperCase).
+        mock("output2")
+
+    }
+
+    //#doc:babel-camel-mock
+
+    routeDef.addRoutesToCamelContext(camelContext)
+
+    camelContext.start()
+
+    val mockEndpoint1 = camelContext.getMockEndpoint("output1")
+    val mockEndpoint2 = camelContext.getMockEndpoint("output2")
+
+    mockEndpoint1.expectedBodiesReceived("test")
+    mockEndpoint2.expectedBodiesReceived("TEST")
+
+    val producer = camelContext.createProducerTemplate()
+
+    producer.sendBody("direct:input", "test")
+
+    mockEndpoint1.assertIsSatisfied()
+    mockEndpoint2.assertIsSatisfied()
+
+    camelContext.shutdown()
+
+  }
+}
+

--- a/babel-doc/source/camel/mock.rst
+++ b/babel-doc/source/camel/mock.rst
@@ -26,3 +26,5 @@ For testing a mock endpoint can be declared with the mock endpoint.
 
 .. includecode:: ../../../babel-camel/babel-camel-mock/src/test/scala/io/xtech/babel/camel/MockSpec.scala#doc:babel-camel-mock
 
+The mock keyword keeps the type of the payload as the mock component do not modify the received messages in most of the cases. For more complexe cases, such as when using ``returnReplyBody``, you may fallback to the legacy way to define mock endpoints.
+

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -53,14 +53,14 @@ object Build extends Build {
     base = file("babel-camel/babel-camel-core"),
     settings = defaultSettings ++ Dependencies.babelCamelCore++ Seq(
       publishArtifact in(Test, packageBin) := true
-    )
+    ),
+    dependencies = Seq(babelcamelmock % "test->test")
   ).dependsOn(babelfish)
 
 
   lazy val babelcamelmock = Project(id = "babel-camel-mock",
     base = file("babel-camel/babel-camel-mock"),
-    settings = defaultSettings ++ Dependencies.babelCamelMock,
-    dependencies = Seq(babelcamelcore % "compile->compile;test->test")
+    settings = defaultSettings ++ Dependencies.babelCamelMock
   ).dependsOn(babelfish)
 
 


### PR DESCRIPTION
this breaks the dependency from babel-camel-mock to babel-camel-core and thus let us use babel-camel-mock in each camel test we are doing