### PR TITLE
Cpa noeffect

### DIFF
--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/EnricherDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/EnricherDSL.scala
@@ -60,16 +60,16 @@ private[camel] class EnricherDSL[I: ClassTag](protected val baseDsl: BaseDSL[I])
   /**
     * Enrich a message with the data coming from an endpoint using request-reply pattern.
     * @param sink the endpoint.
-    * @param strategy a function that know
-    *                 how the original message and the message coming from the endpoint are aggregated.
-    * @param c converts the endpoint to a Sink.
+    * @param aggregationFunction a function that know
+    *                               how the original message and the message coming from the endpoint are aggregated.
+    * @param convert converts the endpoint to a Sink.
     * @tparam O the output type of the enrichment.
     * @tparam S the native type of the Sink.
     * @return the possibility to add other steps to the current DSL.
     */
-  def enrich[O: ClassTag, S, T: ClassTag](sink: S, strategy: (I, O) => T)(implicit c: S => Sink[I, O]): BaseDSL[T] = {
+  def enrich[O: ClassTag, S, T: ClassTag](sink: S, aggregationFunction: (I, O) => T)(implicit convert: S => Sink[I, O]): BaseDSL[T] = {
 
-    EnrichDefinition(sink, Right(new EnrichBodyAggregationStrategy(strategy)))
+    EnrichDefinition(sink, Right(new EnrichBodyAggregationStrategy(aggregationFunction)))
   }
 
   /**
@@ -115,19 +115,18 @@ private[camel] class EnricherDSL[I: ClassTag](protected val baseDsl: BaseDSL[I])
   /**
     * Enrich a message with data coming from an enpoint. The pollEnrich keyword is polling the endpoint.
     * @param sink the endpoint.
-    * @param strategy a Function that know
-    *                 how the original message and the message coming from the endpoint are aggregated.
+    * @param aggregationFunction a Function that know
+    *                               how the original message and the message coming from the endpoint are aggregated.
     * @param timeout the timeout when polling the endpoint in milliseconds.
-    *                Possible values : -1 (block until there is a message,
-    *                0 don't wait and return immediately, otherwise wait a specific period of time.
-    * @param c converts the endpoint to a Sink.
+    *                Possible values : -1 (block until there is a message, 0 don't wait and return immediately, otherwise wait a specific period of time.
+    * @param convert converts the endpoint to a Sink.
     * @tparam O the output type of the enrichment.
     * @tparam S the native type of the Sink.
     * @return the possibility to add other steps to the current DSL.
     */
-  def pollEnrich[O: ClassTag, S, T: ClassTag](sink: S, strategy: Function2[I, O, T], timeout: Int = -1)(implicit c: S => Sink[I, O]): BaseDSL[T] = {
+  def pollEnrich[O: ClassTag, S, T: ClassTag](sink: S, aggregationFunction: Function2[I, O, T], timeout: Int = -1)(implicit convert: S => Sink[I, O]): BaseDSL[T] = {
 
-    PollEnrichDefinition(sink, Right(new EnrichBodyAggregationStrategy(strategy)), timeout)
+    PollEnrichDefinition(sink, Right(new EnrichBodyAggregationStrategy(aggregationFunction)), timeout)
 
   }
 }

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/HandlerDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/HandlerDSL.scala
@@ -27,7 +27,7 @@ private[camel] class GlobalDSL(override val step: EmptyDefinition = new EmptyDef
   * @tparam I
   */
 private[camel] class HandlerDSL[I: ClassTag](from: FromDSL[I]) {
-  protected[camel] val definition = new HandlerDefinition()
+  private[camel] val definition = new HandlerDefinition()
 
   def handle(block: HandlingDSL[I] => Unit): FromDSL[I] = {
     from.step.next = Some(definition)

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/LogDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/LogDSL.scala
@@ -21,9 +21,9 @@ import scala.reflect.ClassTag
   * DSL adding the log keyword.
   */
 private[camel] class LogDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) extends DSL2BaseDSL[I] {
-  
-  private val bodyExpression : String = "${body}"
-  private def applyPreparation(prepare: (Message[I]) => String) : (Message[I] => Message[String]) = msg => msg.withBody(_ => prepare(msg))
+
+  private val bodyExpression: String = "${body}"
+  private def applyPreparation(prepare: (Message[I]) => String): (Message[I] => Message[String]) = msg => msg.withBody(_ => prepare(msg))
   private def preprocess(prepare: (Message[I]) => String, log: (LogDSL[Any]) => BaseDSL[_]): BaseDSL[I] = {
     new WireTapDSL[I](baseDsl.step).sideEffect(dsl => log(new LogDSL(dsl.process(applyPreparation(prepare)))))
   }
@@ -71,43 +71,43 @@ private[camel] class LogDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) exte
   }
 
   /**
-   * the log keyword.
-   * @param prepare defines how the message is prepared to be logged
-   * @return the possibility to add other steps to the current DSL
-   */
+    * the log keyword.
+    * @param prepare defines how the message is prepared to be logged
+    * @return the possibility to add other steps to the current DSL
+    */
   def log(prepare: (Message[I]) => String): BaseDSL[I] = {
     preprocess(prepare, _.log(bodyExpression))
   }
 
   /**
-   * the log keyword.
-   * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
-   * @param prepare defines how the message is prepared to be logged
-   * @return the possibility to add other steps to the current DSL
-   */
+    * the log keyword.
+    * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
+    * @param prepare defines how the message is prepared to be logged
+    * @return the possibility to add other steps to the current DSL
+    */
   def log(logLevel: LoggingLevel, prepare: (Message[I]) => String): BaseDSL[I] = {
     preprocess(prepare, _.log(logLevel, bodyExpression))
   }
 
   /**
-   * the log keyword.
-   * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
-   * @param logName is used by the log engine to select which logging appender should be used for this log
-   * @param prepare defines how the message is prepared to be logged
-   * @return the possibility to add other steps to the current DSL
-   */
+    * the log keyword.
+    * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
+    * @param logName is used by the log engine to select which logging appender should be used for this log
+    * @param prepare defines how the message is prepared to be logged
+    * @return the possibility to add other steps to the current DSL
+    */
   def log(logLevel: LoggingLevel, logName: String, prepare: (Message[I]) => String): BaseDSL[I] = {
     preprocess(prepare, _.log(logLevel, logName, bodyExpression))
   }
 
   /**
-   * the log keyword.
-   * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
-   * @param logName is used by the log engine to select which logging appender should be used for this log
-   * @param marker is used to "tag" this log
-   * @param prepare defines how the message is prepared to be logged
-   * @return the possibility to add other steps to the current DSL
-   */
+    * the log keyword.
+    * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
+    * @param logName is used by the log engine to select which logging appender should be used for this log
+    * @param marker is used to "tag" this log
+    * @param prepare defines how the message is prepared to be logged
+    * @return the possibility to add other steps to the current DSL
+    */
   def log(logLevel: LoggingLevel, logName: String, marker: String, prepare: (Message[I]) => String): BaseDSL[I] = {
     preprocess(prepare, _.log(logLevel, logName, marker, bodyExpression))
   }

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/LogDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/LogDSL.scala
@@ -9,8 +9,10 @@
 package io.xtech.babel.camel
 
 import io.xtech.babel.camel.model._
+import io.xtech.babel.fish.model.Message
 import io.xtech.babel.fish.{ BaseDSL, DSL2BaseDSL }
 import org.apache.camel.LoggingLevel
+import org.apache.camel.language.simple.SimpleLanguage
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
@@ -19,6 +21,12 @@ import scala.reflect.ClassTag
   * DSL adding the log keyword.
   */
 private[camel] class LogDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) extends DSL2BaseDSL[I] {
+  
+  private val bodyExpression : String = "${body}"
+  private def applyPreparation(prepare: (Message[I]) => String) : (Message[I] => Message[String]) = msg => msg.withBody(_ => prepare(msg))
+  private def preprocess(prepare: (Message[I]) => String, log: (LogDSL[Any]) => BaseDSL[_]): BaseDSL[I] = {
+    new WireTapDSL[I](baseDsl.step).wiretap(dsl => log(new LogDSL(dsl.process(applyPreparation(prepare)))))
+  }
 
   /**
     * the log keyword.
@@ -60,6 +68,48 @@ private[camel] class LogDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) exte
     */
   def log(logLevel: LoggingLevel, logName: String, marker: String, output: String): BaseDSL[I] = {
     LogDefinition(LogLoggingLevelLogNameMarkerMessage(logLevel, logName, marker, output))
+  }
+
+  /**
+   * the log keyword.
+   * @param prepare defines how the message is prepared to be logged
+   * @return the possibility to add other steps to the current DSL
+   */
+  def log(prepare: (Message[I]) => String): BaseDSL[I] = {
+    preprocess(prepare, _.log(bodyExpression))
+  }
+
+  /**
+   * the log keyword.
+   * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
+   * @param prepare defines how the message is prepared to be logged
+   * @return the possibility to add other steps to the current DSL
+   */
+  def log(logLevel: LoggingLevel, prepare: (Message[I]) => String): BaseDSL[I] = {
+    preprocess(prepare, _.log(logLevel, bodyExpression))
+  }
+
+  /**
+   * the log keyword.
+   * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
+   * @param logName is used by the log engine to select which logging appender should be used for this log
+   * @param prepare defines how the message is prepared to be logged
+   * @return the possibility to add other steps to the current DSL
+   */
+  def log(logLevel: LoggingLevel, logName: String, prepare: (Message[I]) => String): BaseDSL[I] = {
+    preprocess(prepare, _.log(logLevel, logName, bodyExpression))
+  }
+
+  /**
+   * the log keyword.
+   * @param logLevel defines the minimal LoggingLevel required to let this output been shown in the logs
+   * @param logName is used by the log engine to select which logging appender should be used for this log
+   * @param marker is used to "tag" this log
+   * @param prepare defines how the message is prepared to be logged
+   * @return the possibility to add other steps to the current DSL
+   */
+  def log(logLevel: LoggingLevel, logName: String, marker: String, prepare: (Message[I]) => String): BaseDSL[I] = {
+    preprocess(prepare, _.log(logLevel, logName, marker, bodyExpression))
   }
 }
 

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/LogDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/LogDSL.scala
@@ -25,7 +25,7 @@ private[camel] class LogDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) exte
   private val bodyExpression : String = "${body}"
   private def applyPreparation(prepare: (Message[I]) => String) : (Message[I] => Message[String]) = msg => msg.withBody(_ => prepare(msg))
   private def preprocess(prepare: (Message[I]) => String, log: (LogDSL[Any]) => BaseDSL[_]): BaseDSL[I] = {
-    new WireTapDSL[I](baseDsl.step).wiretap(dsl => log(new LogDSL(dsl.process(applyPreparation(prepare)))))
+    new WireTapDSL[I](baseDsl.step).sideEffect(dsl => log(new LogDSL(dsl.process(applyPreparation(prepare)))))
   }
 
   /**

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/WireTapDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/WireTapDSL.scala
@@ -8,23 +8,53 @@
 
 package io.xtech.babel.camel
 
-import io.xtech.babel.camel.model.{ CamelSink, WireTapDefinition }
-import io.xtech.babel.fish.{ BaseDSL, DSL2BaseDSL }
+import io.xtech.babel.camel.model.{CamelSink, WireTapDefinition}
+import io.xtech.babel.camel.parsing.Wiring
+import io.xtech.babel.fish.model.{Message, StepDefinition, TransformerDefinition}
+import io.xtech.babel.fish.{BaseDSL, DSL2BaseDSL, MessageTransformationExpression}
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**
-  * Adds the wiretap keyword to the BaseDSL.
-  */
+ * Adds the wiretap keyword to the BaseDSL.
+ */
 private[camel] class WireTapDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) extends DSL2BaseDSL[I] {
 
   /**
-    * The wiretap keyword. Defines an endpoint where a copy of exchanges are forwarded, leaving the normal flow of the route.
-    * @param uri of the endpoint which receives a copy of each exchange
-    * @return the possibility to add other steps to the current DSL
-    */
+   * The wiretap keyword. Defines an endpoint where a copy of exchanges are forwarded, leaving the normal flow of the route.
+   * @param uri of the endpoint which receives a copy of each exchange
+   * @return the possibility to add other steps to the current DSL
+   */
   def wiretap(uri: String): BaseDSL[I] = WireTapDefinition[I](CamelSink[I](uri))
+
+  def wiretap(w: (BaseDSL[I]) => BaseDSL[_]): BaseDSL[I] = {
+    val wireDefinition = new TransformerDefinition(wire)
+    val dewireDefinition = new TransformerDefinition(dewire)
+
+    baseDsl.step.next = Some(wireDefinition)
+    val dsl = new BaseDSL[I](wireDefinition)
+
+    w(dsl).step.next = Some(dewireDefinition)
+    new BaseDSL[I](dewireDefinition)
+  }
+
+  private val wire: MessageTransformationExpression[I, I] = MessageTransformationExpression((msg: Message[I]) => {
+    val headers = Wiring.getHeaderCount(msg)
+    msg.withHeader(s"${Wiring.headerKey}-${headers + 1}", msg.body.get) //TODO getOrElse
+  })
+
+
+  private val dewire: MessageTransformationExpression[I, I] = MessageTransformationExpression((msg: Message[I]) => {
+    val headers = Wiring.getHeaderCount(msg)
+    val headerKey = s"${Wiring.headerKey}-${headers}"
+    val body = msg.headers.get(headerKey) match {
+      case i: Some[I] => i.get
+      case other => throw new Exception(s"unepected dewired $other")
+    }
+    msg.withBody(_ => body).withHeaders(_ - headerKey)
+  })
 
 }
 
+class WiringDefinition() extends StepDefinition

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/WireTapDSL.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/WireTapDSL.scala
@@ -8,24 +8,24 @@
 
 package io.xtech.babel.camel
 
-import io.xtech.babel.camel.model.{CamelMessage, CamelSink, WireTapDefinition}
+import io.xtech.babel.camel.model.{ CamelMessage, CamelSink, WireTapDefinition }
 import io.xtech.babel.camel.parsing.Wiring
-import io.xtech.babel.fish.model.{Message, StepDefinition, TransformerDefinition}
-import io.xtech.babel.fish.{BaseDSL, DSL2BaseDSL, MessageTransformationExpression}
+import io.xtech.babel.fish.model.{ Message, StepDefinition, TransformerDefinition }
+import io.xtech.babel.fish.{ BaseDSL, DSL2BaseDSL, MessageTransformationExpression }
 
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 
 /**
- * Adds the wiretap keyword to the BaseDSL.
- */
+  * Adds the wiretap keyword to the BaseDSL.
+  */
 private[camel] class WireTapDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) extends DSL2BaseDSL[I] {
 
   /**
-   * The wiretap keyword. Defines an endpoint where a copy of exchanges are forwarded, leaving the normal flow of the route.
-   * @param uri of the endpoint which receives a copy of each exchange
-   * @return the possibility to add other steps to the current DSL
-   */
+    * The wiretap keyword. Defines an endpoint where a copy of exchanges are forwarded, leaving the normal flow of the route.
+    * @param uri of the endpoint which receives a copy of each exchange
+    * @return the possibility to add other steps to the current DSL
+    */
   def wiretap(uri: String): BaseDSL[I] = WireTapDefinition[I](CamelSink[I](uri))
 
   def sideEffect(w: (BaseDSL[I]) => BaseDSL[_]): BaseDSL[I] = {
@@ -44,12 +44,11 @@ private[camel] class WireTapDSL[I: ClassTag](protected val baseDsl: BaseDSL[I]) 
     msg.asInstanceOf[CamelMessage[I]].withExchangeProperty(s"${Wiring.key}-${headers + 1}", msg.body.get) //TODO getOrElse
   })
 
-
   private val dewire: MessageTransformationExpression[I, I] = MessageTransformationExpression((msg: Message[I]) => {
     val key = s"${Wiring.key}-${Wiring.getCount(msg) + 1}"
     val body = msg.asInstanceOf[CamelMessage[_]].exchangeProperties.get(key) match {
       case i: Some[I] => i.get
-      case other => throw new Exception(s"unepected dewired $other")
+      case other      => throw new Exception(s"unepected dewired body type $other") //should never happen
     }
     msg.withBody(_ => body).withHeaders(_ - key)
   })

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/WireTapDefinition.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/model/WireTapDefinition.scala
@@ -8,9 +8,11 @@
 
 package io.xtech.babel.camel.model
 
+import io.xtech.babel.fish.BaseDSL
 import io.xtech.babel.fish.model.StepDefinition
 
 /**
   * Defines a sink where each message is just copied.
   */
 case class WireTapDefinition[T](sink: CamelSink[T]) extends StepDefinition
+

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
@@ -41,10 +41,10 @@ private[babel] trait WireTap extends CamelParsing {
 }
 
 object Wiring {
-  val headerKey: String = "babel-wiring-body"
+  val key: String = "babel-wiring-body"
 
-  def getHeaderCount(msg: Message[_]): Int = {
-    msg.headers.keys.count(_.startsWith(Wiring.headerKey))
+  def getCount(msg: Message[_]): Int = {
+    msg.headers.keys.count(_.startsWith(Wiring.key))
   }
 
 

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
@@ -8,8 +8,8 @@
 
 package io.xtech.babel.camel.parsing
 
-import io.xtech.babel.camel.model.WireTapDefinition
 import io.xtech.babel.camel.{ CamelDSL, WireTapDSL }
+import io.xtech.babel.camel.model.WireTapDefinition
 import io.xtech.babel.fish.BaseDSL
 import io.xtech.babel.fish.model.Message
 import io.xtech.babel.fish.parsing.StepInformation

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
@@ -36,7 +36,7 @@ private[babel] trait WireTap extends CamelParsing {
     }
 
   }
-  
+
   protected implicit def wiretapDSLExtension[I: ClassTag](baseDsl: BaseDSL[I]) = new WireTapDSL(baseDsl)
 }
 
@@ -46,6 +46,5 @@ object Wiring {
   def getCount(msg: Message[_]): Int = {
     msg.headers.keys.count(_.startsWith(Wiring.key))
   }
-
 
 }

--- a/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
+++ b/babel-camel/babel-camel-core/src/main/scala/io/xtech/babel/camel/parsing/WireTap.scala
@@ -11,6 +11,7 @@ package io.xtech.babel.camel.parsing
 import io.xtech.babel.camel.model.WireTapDefinition
 import io.xtech.babel.camel.{ CamelDSL, WireTapDSL }
 import io.xtech.babel.fish.BaseDSL
+import io.xtech.babel.fish.model.Message
 import io.xtech.babel.fish.parsing.StepInformation
 import org.apache.camel.model.ProcessorDefinition
 
@@ -35,6 +36,16 @@ private[babel] trait WireTap extends CamelParsing {
     }
 
   }
-
+  
   protected implicit def wiretapDSLExtension[I: ClassTag](baseDsl: BaseDSL[I]) = new WireTapDSL(baseDsl)
+}
+
+object Wiring {
+  val headerKey: String = "babel-wiring-body"
+
+  def getHeaderCount(msg: Message[_]): Int = {
+    msg.headers.keys.count(_.startsWith(Wiring.headerKey))
+  }
+
+
 }

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
@@ -90,16 +90,15 @@ class WireTapSpec extends SpecificationWithJUnit {
         .to("mock:output")
       //#doc:babel-camel-wiretap-functional
 
-
     }
 
     routeDef.addRoutesToCamelContext(camelContext)
 
     camelContext.start()
 
-    val mockEndpointBI = camelContext.getEndpoint("mock:in-wire").asInstanceOf[MockEndpoint]
-    val mockEndpointBO = camelContext.getEndpoint("mock:out-wire").asInstanceOf[MockEndpoint]
-    val mockEndpointBT = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+    val mockEndpointBI = camelContext.mockEndpoint("in-wire")
+    val mockEndpointBO = camelContext.mockEndpoint("out-wire")
+    val mockEndpointBT = camelContext.mockEndpoint("output")
 
     mockEndpointBI.expectedBodiesReceived(testMessage)
     mockEndpointBO.expectedBodiesReceived(wireTapMessage)

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
@@ -86,7 +86,7 @@ class WireTapSpec extends SpecificationWithJUnit {
       from("direct:input-babel").
         //Incoming messages are sent to the direct endpoint
         //   and to the next mock endpoint
-        wiretap(_.to("mock:in-wire").processBody(_ => wireTapMessage).to("mock:out-wire"))
+        sideEffect(_.to("mock:in-wire").processBody(_ => wireTapMessage).to("mock:out-wire"))
         .to("mock:output")
       //#doc:babel-camel-wiretap-functional
 

--- a/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
+++ b/babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/WireTapSpec.scala
@@ -16,7 +16,7 @@ import org.specs2.mutable.SpecificationWithJUnit
 class WireTapSpec extends SpecificationWithJUnit {
   sequential
 
-  "create a multicast,aggregate route" in new camel {
+  "create a wire-tap" in new camel {
 
     val testMessage = "test"
     val wireTapMessage = "tap"
@@ -70,6 +70,47 @@ class WireTapSpec extends SpecificationWithJUnit {
     mockEndpointC.assertIsSatisfied()
     mockEndpointCT.assertIsSatisfied()
     mockEndpointB.assertIsSatisfied()
+    mockEndpointBT.assertIsSatisfied()
+
+  }
+
+  "create a functionnal wire-tap" in new camel {
+
+    val testMessage = "test"
+    val wireTapMessage = "tap"
+
+    import io.xtech.babel.camel.builder.RouteBuilder
+
+    val routeDef = new RouteBuilder {
+      //#doc:babel-camel-wiretap-functional
+      from("direct:input-babel").
+        //Incoming messages are sent to the direct endpoint
+        //   and to the next mock endpoint
+        wiretap(_.to("mock:in-wire").processBody(_ => wireTapMessage).to("mock:out-wire"))
+        .to("mock:output")
+      //#doc:babel-camel-wiretap-functional
+
+
+    }
+
+    routeDef.addRoutesToCamelContext(camelContext)
+
+    camelContext.start()
+
+    val mockEndpointBI = camelContext.getEndpoint("mock:in-wire").asInstanceOf[MockEndpoint]
+    val mockEndpointBO = camelContext.getEndpoint("mock:out-wire").asInstanceOf[MockEndpoint]
+    val mockEndpointBT = camelContext.getEndpoint("mock:output").asInstanceOf[MockEndpoint]
+
+    mockEndpointBI.expectedBodiesReceived(testMessage)
+    mockEndpointBO.expectedBodiesReceived(wireTapMessage)
+    mockEndpointBT.expectedBodiesReceived(testMessage)
+
+    val producer = camelContext.createProducerTemplate()
+
+    producer.sendBody("direct:input-babel", testMessage)
+
+    mockEndpointBI.assertIsSatisfied()
+    mockEndpointBO.assertIsSatisfied()
     mockEndpointBT.assertIsSatisfied()
 
   }

--- a/babel-doc/source/camel/basics.rst
+++ b/babel-doc/source/camel/basics.rst
@@ -76,6 +76,10 @@ With a **log**, you can log a defined string (which may use Camel Simple Express
 
 .. includecode:: ../../../babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/LogSpec.scala#doc:babel-camel-logging
 
+You may also use a function to define what should be logged:
+
+.. includecode:: ../../../babel-camel/babel-camel-core/src/test/scala/io/xtech/babel/camel/LogSpec.scala#doc:babel-camel-logging-functionnal
+
 Route configuration
 +++++++++++++++++++
 


### PR DESCRIPTION
this provides a new EIP: sideEffect that takes as parameter a part of route that should not impact the rest of the route.

For the moment, only the exchange is stored and replaced, might be useful to do it also for headers?